### PR TITLE
feat(webapp): expose all ModelConfig parameters and load defaults from YAML

### DIFF
--- a/src/companies_house_abm/webapp/app.py
+++ b/src/companies_house_abm/webapp/app.py
@@ -32,10 +32,201 @@ def index() -> FileResponse:
     return FileResponse(str(_STATIC_DIR / "index.html"))
 
 
+# ---------------------------------------------------------------------------
+# Helpers: mapping between the flat API model and the nested ModelConfig
+# ---------------------------------------------------------------------------
+
+
+def _config_to_params(cfg: object) -> SimulationParams:
+    """Convert a :class:`ModelConfig` to a flat :class:`SimulationParams`.
+
+    Values are clamped to the Pydantic field bounds where the YAML config
+    contains larger values than the web UI supports (e.g. 50 000 firms).
+    """
+    from companies_house_abm.abm.config import ModelConfig
+
+    if not isinstance(cfg, ModelConfig):
+        return SimulationParams()
+
+    def _clamp(v: float, lo: float, hi: float) -> float:
+        return max(lo, min(hi, v))
+
+    return SimulationParams(
+        # Simulation
+        periods=int(_clamp(cfg.simulation.periods, 10, 400)),
+        seed=cfg.simulation.seed,
+        # Firms — population
+        n_firms=int(_clamp(cfg.firms.sample_size, 10, 100_000)),
+        firm_entry_rate=cfg.firms.entry_rate,
+        firm_exit_threshold=cfg.firms.exit_threshold,
+        # Firms — behaviour
+        price_markup=cfg.firm_behavior.price_markup,
+        markup_adjustment_speed=cfg.firm_behavior.markup_adjustment_speed,
+        inventory_target_ratio=cfg.firm_behavior.inventory_target_ratio,
+        capacity_utilization_target=cfg.firm_behavior.capacity_utilization_target,
+        investment_sensitivity=cfg.firm_behavior.investment_sensitivity,
+        wage_adjustment_speed=cfg.firm_behavior.wage_adjustment_speed,
+        # Households — population
+        n_households=int(_clamp(cfg.households.count, 50, 50_000)),
+        income_mean=cfg.households.income_mean,
+        income_std=cfg.households.income_std,
+        wealth_shape=cfg.households.wealth_shape,
+        # Households — behaviour
+        mpc_mean=cfg.households.mpc_mean,
+        mpc_std=cfg.households.mpc_std,
+        job_search_intensity=cfg.household_behavior.job_search_intensity,
+        reservation_wage_ratio=cfg.household_behavior.reservation_wage_ratio,
+        consumption_smoothing=cfg.household_behavior.consumption_smoothing,
+        # Banks — population
+        n_banks=cfg.banks.count,
+        capital_requirement=cfg.banks.capital_requirement,
+        reserve_requirement=cfg.banks.reserve_requirement,
+        # Banks — behaviour
+        base_interest_markup=cfg.bank_behavior.base_interest_markup,
+        risk_premium_sensitivity=cfg.bank_behavior.risk_premium_sensitivity,
+        lending_threshold=cfg.bank_behavior.lending_threshold,
+        capital_buffer=cfg.bank_behavior.capital_buffer,
+        # Central bank (Taylor rule)
+        inflation_target=cfg.taylor_rule.inflation_target,
+        inflation_coefficient=cfg.taylor_rule.inflation_coefficient,
+        output_gap_coefficient=cfg.taylor_rule.output_gap_coefficient,
+        interest_rate_smoothing=cfg.taylor_rule.interest_rate_smoothing,
+        lower_bound=cfg.taylor_rule.lower_bound,
+        # Government (fiscal rule)
+        spending_gdp_ratio=cfg.fiscal_rule.spending_gdp_ratio,
+        corporate_tax_rate=cfg.fiscal_rule.tax_rate_corporate,
+        income_tax_rate=cfg.fiscal_rule.tax_rate_income_base,
+        tax_progressivity=cfg.fiscal_rule.tax_progressivity,
+        deficit_target=cfg.fiscal_rule.deficit_target,
+        deficit_adjustment_speed=cfg.fiscal_rule.deficit_adjustment_speed,
+        # Transfers
+        unemployment_benefit_ratio=cfg.transfers.unemployment_benefit_ratio,
+        pension_ratio=cfg.transfers.pension_ratio,
+        # Goods market
+        price_adjustment_speed=cfg.goods_market.price_adjustment_speed,
+        quantity_adjustment_speed=cfg.goods_market.quantity_adjustment_speed,
+        goods_search_intensity=cfg.goods_market.search_intensity,
+        # Labour market
+        wage_stickiness=cfg.labor_market.wage_stickiness,
+        matching_efficiency=cfg.labor_market.matching_efficiency,
+        separation_rate=cfg.labor_market.separation_rate,
+        phillips_curve_slope=cfg.labor_market.phillips_curve_slope,
+        # Credit market
+        collateral_requirement=cfg.credit_market.collateral_requirement,
+        default_rate_base=cfg.credit_market.default_rate_base,
+    )
+
+
+def _params_to_config(params: SimulationParams) -> object:
+    """Convert a flat :class:`SimulationParams` to a :class:`ModelConfig`."""
+    from companies_house_abm.abm.config import (
+        BankBehaviorConfig,
+        BankConfig,
+        CreditMarketConfig,
+        FirmBehaviorConfig,
+        FirmConfig,
+        FiscalRuleConfig,
+        GoodsMarketConfig,
+        HouseholdBehaviorConfig,
+        HouseholdConfig,
+        LaborMarketConfig,
+        ModelConfig,
+        SimulationConfig,
+        TaylorRuleConfig,
+        TransfersConfig,
+    )
+
+    return ModelConfig(
+        simulation=SimulationConfig(
+            periods=params.periods,
+            seed=params.seed,
+        ),
+        firms=FirmConfig(
+            sample_size=params.n_firms,
+            entry_rate=params.firm_entry_rate,
+            exit_threshold=params.firm_exit_threshold,
+        ),
+        firm_behavior=FirmBehaviorConfig(
+            price_markup=params.price_markup,
+            markup_adjustment_speed=params.markup_adjustment_speed,
+            inventory_target_ratio=params.inventory_target_ratio,
+            capacity_utilization_target=params.capacity_utilization_target,
+            investment_sensitivity=params.investment_sensitivity,
+            wage_adjustment_speed=params.wage_adjustment_speed,
+        ),
+        households=HouseholdConfig(
+            count=params.n_households,
+            income_mean=params.income_mean,
+            income_std=params.income_std,
+            wealth_shape=params.wealth_shape,
+            mpc_mean=params.mpc_mean,
+            mpc_std=params.mpc_std,
+        ),
+        household_behavior=HouseholdBehaviorConfig(
+            job_search_intensity=params.job_search_intensity,
+            reservation_wage_ratio=params.reservation_wage_ratio,
+            consumption_smoothing=params.consumption_smoothing,
+        ),
+        banks=BankConfig(
+            count=params.n_banks,
+            capital_requirement=params.capital_requirement,
+            reserve_requirement=params.reserve_requirement,
+        ),
+        bank_behavior=BankBehaviorConfig(
+            base_interest_markup=params.base_interest_markup,
+            risk_premium_sensitivity=params.risk_premium_sensitivity,
+            lending_threshold=params.lending_threshold,
+            capital_buffer=params.capital_buffer,
+        ),
+        taylor_rule=TaylorRuleConfig(
+            inflation_target=params.inflation_target,
+            inflation_coefficient=params.inflation_coefficient,
+            output_gap_coefficient=params.output_gap_coefficient,
+            interest_rate_smoothing=params.interest_rate_smoothing,
+            lower_bound=params.lower_bound,
+        ),
+        fiscal_rule=FiscalRuleConfig(
+            spending_gdp_ratio=params.spending_gdp_ratio,
+            tax_rate_corporate=params.corporate_tax_rate,
+            tax_rate_income_base=params.income_tax_rate,
+            tax_progressivity=params.tax_progressivity,
+            deficit_target=params.deficit_target,
+            deficit_adjustment_speed=params.deficit_adjustment_speed,
+        ),
+        transfers=TransfersConfig(
+            unemployment_benefit_ratio=params.unemployment_benefit_ratio,
+            pension_ratio=params.pension_ratio,
+        ),
+        goods_market=GoodsMarketConfig(
+            price_adjustment_speed=params.price_adjustment_speed,
+            quantity_adjustment_speed=params.quantity_adjustment_speed,
+            search_intensity=params.goods_search_intensity,
+        ),
+        labor_market=LaborMarketConfig(
+            wage_stickiness=params.wage_stickiness,
+            matching_efficiency=params.matching_efficiency,
+            separation_rate=params.separation_rate,
+            phillips_curve_slope=params.phillips_curve_slope,
+        ),
+        credit_market=CreditMarketConfig(
+            collateral_requirement=params.collateral_requirement,
+            default_rate_base=params.default_rate_base,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+
 @app.get("/api/defaults", response_model=DefaultsResponse)
 def get_defaults() -> DefaultsResponse:
-    """Return the default simulation parameters."""
-    return DefaultsResponse(params=SimulationParams())
+    """Return the default simulation parameters loaded from the config file."""
+    from companies_house_abm.abm.config import load_config
+
+    cfg = load_config()
+    return DefaultsResponse(params=_config_to_params(cfg))
 
 
 @app.post("/api/simulate", response_model=SimulationResponse)
@@ -45,54 +236,10 @@ def run_simulation(params: SimulationParams) -> SimulationResponse:
     The simulation is configured from the supplied parameters and run
     synchronously.  Results include one record per simulated quarter.
     """
-    from companies_house_abm.abm.config import (
-        BankBehaviorConfig,
-        BankConfig,
-        FirmBehaviorConfig,
-        FirmConfig,
-        FiscalRuleConfig,
-        HouseholdBehaviorConfig,
-        HouseholdConfig,
-        ModelConfig,
-        SimulationConfig,
-        TaylorRuleConfig,
-    )
     from companies_house_abm.abm.model import Simulation
 
-    config = ModelConfig(
-        simulation=SimulationConfig(
-            periods=params.periods,
-            seed=params.seed,
-        ),
-        firms=FirmConfig(
-            sample_size=params.n_firms,
-        ),
-        firm_behavior=FirmBehaviorConfig(
-            price_markup=params.price_markup,
-        ),
-        households=HouseholdConfig(
-            count=params.n_households,
-            mpc_mean=params.mpc_mean,
-        ),
-        household_behavior=HouseholdBehaviorConfig(),
-        banks=BankConfig(
-            count=params.n_banks,
-            capital_requirement=params.capital_requirement,
-        ),
-        bank_behavior=BankBehaviorConfig(),
-        taylor_rule=TaylorRuleConfig(
-            inflation_target=params.inflation_target,
-            inflation_coefficient=params.inflation_coefficient,
-            output_gap_coefficient=params.output_gap_coefficient,
-        ),
-        fiscal_rule=FiscalRuleConfig(
-            spending_gdp_ratio=params.spending_gdp_ratio,
-            tax_rate_corporate=params.corporate_tax_rate,
-            tax_rate_income_base=params.income_tax_rate,
-        ),
-    )
-
-    sim = Simulation(config)
+    config = _params_to_config(params)
+    sim = Simulation(config)  # type: ignore[arg-type]
     sim.initialize_agents()
     result = sim.run(periods=params.periods)
 

--- a/src/companies_house_abm/webapp/models.py
+++ b/src/companies_house_abm/webapp/models.py
@@ -8,64 +8,186 @@ from pydantic import BaseModel, Field
 class SimulationParams(BaseModel):
     """Parameters configuring a simulation run."""
 
-    # Simulation
+    # ── Simulation ────────────────────────────────────────────────────────────
     periods: int = Field(
         80, ge=10, le=400, description="Number of quarters to simulate"
     )
     seed: int = Field(42, ge=0, description="Random seed for reproducibility")
 
-    # Firms
-    n_firms: int = Field(100, ge=10, le=1000, description="Number of firm agents")
+    # ── Firms — population ───────────────────────────────────────────────────
+    n_firms: int = Field(100, ge=10, le=100_000, description="Number of firm agents")
+    firm_entry_rate: float = Field(
+        0.02, ge=0.0, le=0.20, description="Firm entry rate per period"
+    )
+    firm_exit_threshold: float = Field(
+        -0.5, ge=-2.0, le=0.0, description="Equity/assets ratio triggering bankruptcy"
+    )
+
+    # ── Firms — behaviour ────────────────────────────────────────────────────
     price_markup: float = Field(
         0.15, ge=0.01, le=0.50, description="Initial price markup"
     )
+    markup_adjustment_speed: float = Field(
+        0.10, ge=0.01, le=0.50, description="Speed of markup adjustment"
+    )
+    inventory_target_ratio: float = Field(
+        0.20,
+        ge=0.05,
+        le=0.60,
+        description="Inventory target as fraction of expected sales",
+    )
+    capacity_utilization_target: float = Field(
+        0.85, ge=0.50, le=1.00, description="Target capacity utilisation"
+    )
+    investment_sensitivity: float = Field(
+        2.0, ge=0.5, le=5.0, description="Investment sensitivity to profitability gap"
+    )
+    wage_adjustment_speed: float = Field(
+        0.05, ge=0.01, le=0.30, description="Speed of firm wage adjustment"
+    )
 
-    # Households
+    # ── Households — population ──────────────────────────────────────────────
     n_households: int = Field(
-        500, ge=50, le=5000, description="Number of household agents"
+        500, ge=50, le=50_000, description="Number of household agents"
     )
+    income_mean: float = Field(
+        35_000.0,
+        ge=10_000.0,
+        le=100_000.0,
+        description="Mean annual household income (£)",
+    )
+    income_std: float = Field(
+        15_000.0,
+        ge=1_000.0,
+        le=50_000.0,
+        description="Std dev of annual household income (£)",
+    )
+    wealth_shape: float = Field(
+        1.5,
+        ge=0.5,
+        le=5.0,
+        description="Pareto shape parameter for wealth distribution",
+    )
+
+    # ── Households — behaviour ───────────────────────────────────────────────
     mpc_mean: float = Field(
-        0.8,
-        ge=0.3,
-        le=0.99,
-        description="Mean marginal propensity to consume",
+        0.8, ge=0.3, le=0.99, description="Mean marginal propensity to consume"
+    )
+    mpc_std: float = Field(
+        0.1, ge=0.01, le=0.30, description="Std dev of MPC across households"
+    )
+    job_search_intensity: float = Field(
+        0.3, ge=0.05, le=1.0, description="Fraction of vacancies searched per period"
+    )
+    reservation_wage_ratio: float = Field(
+        0.9, ge=0.5, le=1.0, description="Reservation wage as fraction of market wage"
+    )
+    consumption_smoothing: float = Field(
+        0.7, ge=0.0, le=1.0, description="Weight on permanent vs current income"
     )
 
-    # Banks
-    n_banks: int = Field(10, ge=1, le=20, description="Number of bank agents")
+    # ── Banks — population ───────────────────────────────────────────────────
+    n_banks: int = Field(10, ge=1, le=50, description="Number of bank agents")
     capital_requirement: float = Field(
-        0.10, ge=0.04, le=0.30, description="Bank capital requirement ratio"
+        0.10, ge=0.04, le=0.30, description="Regulatory capital requirement ratio"
+    )
+    reserve_requirement: float = Field(
+        0.01, ge=0.0, le=0.10, description="Reserve requirement ratio"
     )
 
-    # Central bank (Taylor rule)
+    # ── Banks — behaviour ────────────────────────────────────────────────────
+    base_interest_markup: float = Field(
+        0.02, ge=0.0, le=0.10, description="Base lending rate markup over policy rate"
+    )
+    risk_premium_sensitivity: float = Field(
+        0.05,
+        ge=0.0,
+        le=0.30,
+        description="Sensitivity of risk premium to borrower leverage",
+    )
+    lending_threshold: float = Field(
+        0.3, ge=0.0, le=1.0, description="Minimum coverage ratio for new lending"
+    )
+    capital_buffer: float = Field(
+        0.02, ge=0.0, le=0.15, description="Capital buffer above regulatory minimum"
+    )
+
+    # ── Central bank (Taylor rule) ───────────────────────────────────────────
     inflation_target: float = Field(
         0.02, ge=0.005, le=0.10, description="Inflation target"
     )
     inflation_coefficient: float = Field(
-        1.5,
-        ge=1.0,
-        le=3.0,
-        description="Taylor rule inflation coefficient",
+        1.5, ge=1.0, le=3.0, description="Taylor rule inflation gap coefficient"
     )
     output_gap_coefficient: float = Field(
-        0.5,
-        ge=0.0,
-        le=1.5,
-        description="Taylor rule output gap coefficient",
+        0.5, ge=0.0, le=1.5, description="Taylor rule output gap coefficient"
+    )
+    interest_rate_smoothing: float = Field(
+        0.8, ge=0.0, le=0.99, description="Interest rate smoothing (inertia) parameter"
+    )
+    lower_bound: float = Field(
+        0.001, ge=0.0, le=0.05, description="Effective lower bound on policy rate"
     )
 
-    # Government (fiscal rule)
+    # ── Government (fiscal rule) ─────────────────────────────────────────────
     spending_gdp_ratio: float = Field(
-        0.40,
-        ge=0.15,
-        le=0.65,
-        description="Government spending as share of GDP",
+        0.40, ge=0.15, le=0.65, description="Government spending as share of GDP"
     )
     corporate_tax_rate: float = Field(
         0.19, ge=0.05, le=0.40, description="Corporate tax rate"
     )
     income_tax_rate: float = Field(
         0.20, ge=0.05, le=0.50, description="Base income tax rate"
+    )
+    tax_progressivity: float = Field(
+        0.10, ge=0.0, le=0.50, description="Tax progressivity parameter"
+    )
+    deficit_target: float = Field(
+        0.03, ge=0.0, le=0.15, description="Target deficit as fraction of GDP"
+    )
+    deficit_adjustment_speed: float = Field(
+        0.10, ge=0.0, le=0.50, description="Speed of fiscal rule adjustment"
+    )
+
+    # ── Transfers ────────────────────────────────────────────────────────────
+    unemployment_benefit_ratio: float = Field(
+        0.4, ge=0.1, le=0.9, description="Unemployment benefit replacement rate"
+    )
+    pension_ratio: float = Field(
+        0.3, ge=0.1, le=0.8, description="Pension as fraction of average wage"
+    )
+
+    # ── Goods market ─────────────────────────────────────────────────────────
+    price_adjustment_speed: float = Field(
+        0.1, ge=0.01, le=0.50, description="Speed of goods price adjustment"
+    )
+    quantity_adjustment_speed: float = Field(
+        0.3, ge=0.05, le=1.0, description="Speed of production quantity adjustment"
+    )
+    goods_search_intensity: float = Field(
+        0.5, ge=0.1, le=1.0, description="Consumer search intensity in goods market"
+    )
+
+    # ── Labour market ────────────────────────────────────────────────────────
+    wage_stickiness: float = Field(
+        0.8, ge=0.0, le=1.0, description="Degree of nominal wage stickiness"
+    )
+    matching_efficiency: float = Field(
+        0.3, ge=0.05, le=1.0, description="Labour market matching efficiency"
+    )
+    separation_rate: float = Field(
+        0.05, ge=0.01, le=0.20, description="Exogenous job separation rate per period"
+    )
+    phillips_curve_slope: float = Field(
+        -0.5, ge=-2.0, le=0.0, description="Wage Phillips curve slope"
+    )
+
+    # ── Credit market ────────────────────────────────────────────────────────
+    collateral_requirement: float = Field(
+        0.5, ge=0.0, le=1.0, description="Required collateral as fraction of loan value"
+    )
+    default_rate_base: float = Field(
+        0.01, ge=0.0, le=0.10, description="Base loan default probability per period"
     )
 
 

--- a/src/companies_house_abm/webapp/static/app.js
+++ b/src/companies_house_abm/webapp/static/app.js
@@ -121,50 +121,91 @@ function fmt_num(v, dp = 2) {
 }
 
 // ── Parameter config ──────────────────────────────────────────────────
+// `default` is a local fallback used only if /api/defaults fails.
 
 const PARAM_GROUPS = [
   {
     label: 'Simulation',
     params: [
-      { key: 'periods',        label: 'Quarters',       min: 10,  max: 200, step: 5,    default: 80,  type: 'range' },
-      { key: 'seed',           label: 'Random seed',    min: 0,   max: 999, step: 1,    default: 42,  type: 'number' },
+      { key: 'periods',        label: 'Quarters',        min: 10,    max: 200,   step: 5,     default: 80,    type: 'range' },
+      { key: 'seed',           label: 'Random seed',     min: 0,     max: 999,   step: 1,     default: 42,    type: 'number' },
     ],
   },
   {
     label: 'Firms',
     params: [
-      { key: 'n_firms',        label: 'Number of firms',min: 10,  max: 500, step: 10,   default: 100, type: 'range' },
-      { key: 'price_markup',   label: 'Price markup',   min: 0.01,max: 0.50,step: 0.01, default: 0.15,type: 'range', pct: true },
+      { key: 'n_firms',                    label: 'Number of firms',        min: 10,    max: 1000,  step: 10,    default: 100,   type: 'range' },
+      { key: 'firm_entry_rate',            label: 'Entry rate',             min: 0.0,   max: 0.20,  step: 0.01,  default: 0.02,  type: 'range', pct: true },
+      { key: 'firm_exit_threshold',        label: 'Exit threshold',         min: -2.0,  max: 0.0,   step: 0.1,   default: -0.5,  type: 'range' },
+      { key: 'price_markup',               label: 'Price markup',           min: 0.01,  max: 0.50,  step: 0.01,  default: 0.15,  type: 'range', pct: true },
+      { key: 'markup_adjustment_speed',    label: 'Markup adj. speed',      min: 0.01,  max: 0.50,  step: 0.01,  default: 0.10,  type: 'range' },
+      { key: 'inventory_target_ratio',     label: 'Inventory target',       min: 0.05,  max: 0.60,  step: 0.05,  default: 0.20,  type: 'range' },
+      { key: 'capacity_utilization_target',label: 'Capacity util. target',  min: 0.50,  max: 1.00,  step: 0.05,  default: 0.85,  type: 'range', pct: true },
+      { key: 'investment_sensitivity',     label: 'Investment sensitivity', min: 0.5,   max: 5.0,   step: 0.5,   default: 2.0,   type: 'range' },
+      { key: 'wage_adjustment_speed',      label: 'Wage adj. speed',        min: 0.01,  max: 0.30,  step: 0.01,  default: 0.05,  type: 'range' },
     ],
   },
   {
     label: 'Households',
     params: [
-      { key: 'n_households',   label: 'Households',     min: 50,  max: 2000,step: 50,   default: 500, type: 'range' },
-      { key: 'mpc_mean',       label: 'Avg MPC',        min: 0.3, max: 0.99,step: 0.01, default: 0.8, type: 'range', pct: true },
+      { key: 'n_households',           label: 'Households',              min: 50,    max: 5000,  step: 50,    default: 500,   type: 'range' },
+      { key: 'income_mean',            label: 'Mean income (£/yr)',       min: 10000, max: 100000,step: 1000,  default: 35000, type: 'range' },
+      { key: 'income_std',             label: 'Income std dev (£)',       min: 1000,  max: 50000, step: 1000,  default: 15000, type: 'range' },
+      { key: 'wealth_shape',           label: 'Wealth Pareto shape',      min: 0.5,   max: 5.0,   step: 0.1,   default: 1.5,   type: 'range' },
+      { key: 'mpc_mean',               label: 'Avg MPC',                  min: 0.3,   max: 0.99,  step: 0.01,  default: 0.8,   type: 'range', pct: true },
+      { key: 'mpc_std',                label: 'MPC std dev',              min: 0.01,  max: 0.30,  step: 0.01,  default: 0.1,   type: 'range' },
+      { key: 'job_search_intensity',   label: 'Job search intensity',     min: 0.05,  max: 1.0,   step: 0.05,  default: 0.3,   type: 'range', pct: true },
+      { key: 'reservation_wage_ratio', label: 'Reservation wage ratio',   min: 0.5,   max: 1.0,   step: 0.05,  default: 0.9,   type: 'range', pct: true },
+      { key: 'consumption_smoothing',  label: 'Consumption smoothing',    min: 0.0,   max: 1.0,   step: 0.05,  default: 0.7,   type: 'range', pct: true },
     ],
   },
   {
     label: 'Banks',
     params: [
-      { key: 'n_banks',        label: 'Banks',          min: 1,   max: 20,  step: 1,    default: 10,  type: 'range' },
-      { key: 'capital_requirement', label: 'Capital req.',min:0.04,max:0.30,step:0.01,  default: 0.10,type: 'range', pct: true },
+      { key: 'n_banks',                  label: 'Banks',                    min: 1,     max: 20,    step: 1,     default: 10,    type: 'range' },
+      { key: 'capital_requirement',      label: 'Capital req.',             min: 0.04,  max: 0.30,  step: 0.01,  default: 0.10,  type: 'range', pct: true },
+      { key: 'reserve_requirement',      label: 'Reserve req.',             min: 0.0,   max: 0.10,  step: 0.005, default: 0.01,  type: 'range', pct: true },
+      { key: 'base_interest_markup',     label: 'Base rate markup',         min: 0.0,   max: 0.10,  step: 0.005, default: 0.02,  type: 'range', pct: true },
+      { key: 'risk_premium_sensitivity', label: 'Risk premium sensitivity', min: 0.0,   max: 0.30,  step: 0.01,  default: 0.05,  type: 'range' },
+      { key: 'lending_threshold',        label: 'Lending threshold',        min: 0.0,   max: 1.0,   step: 0.05,  default: 0.3,   type: 'range', pct: true },
+      { key: 'capital_buffer',           label: 'Capital buffer',           min: 0.0,   max: 0.15,  step: 0.01,  default: 0.02,  type: 'range', pct: true },
     ],
   },
   {
     label: 'Central Bank',
     params: [
-      { key: 'inflation_target',     label: 'Inflation target', min:0.005,max:0.10,step:0.005,default:0.02, type:'range', pct:true },
-      { key: 'inflation_coefficient',label: 'π coefficient',    min:1.0,  max:3.0, step:0.1,  default:1.5,  type:'range' },
-      { key: 'output_gap_coefficient',label:'Gap coefficient',  min:0.0,  max:1.5, step:0.1,  default:0.5,  type:'range' },
+      { key: 'inflation_target',       label: 'Inflation target',         min: 0.005, max: 0.10,  step: 0.005, default: 0.02,  type: 'range', pct: true },
+      { key: 'inflation_coefficient',  label: 'π coefficient',            min: 1.0,   max: 3.0,   step: 0.1,   default: 1.5,   type: 'range' },
+      { key: 'output_gap_coefficient', label: 'Gap coefficient',          min: 0.0,   max: 1.5,   step: 0.1,   default: 0.5,   type: 'range' },
+      { key: 'interest_rate_smoothing',label: 'Rate smoothing',           min: 0.0,   max: 0.99,  step: 0.05,  default: 0.8,   type: 'range', pct: true },
+      { key: 'lower_bound',            label: 'Effective lower bound',    min: 0.0,   max: 0.05,  step: 0.001, default: 0.001, type: 'range', pct: true },
     ],
   },
   {
     label: 'Government',
     params: [
-      { key: 'spending_gdp_ratio', label: 'Gov. spending / GDP', min:0.15,max:0.65,step:0.01,default:0.40,type:'range',pct:true },
-      { key: 'corporate_tax_rate', label: 'Corporate tax',       min:0.05,max:0.40,step:0.01,default:0.19,type:'range',pct:true },
-      { key: 'income_tax_rate',    label: 'Income tax (base)',   min:0.05,max:0.50,step:0.01,default:0.20,type:'range',pct:true },
+      { key: 'spending_gdp_ratio',         label: 'Gov. spending / GDP',    min: 0.15,  max: 0.65,  step: 0.01,  default: 0.40,  type: 'range', pct: true },
+      { key: 'corporate_tax_rate',         label: 'Corporate tax',          min: 0.05,  max: 0.40,  step: 0.01,  default: 0.19,  type: 'range', pct: true },
+      { key: 'income_tax_rate',            label: 'Income tax (base)',       min: 0.05,  max: 0.50,  step: 0.01,  default: 0.20,  type: 'range', pct: true },
+      { key: 'tax_progressivity',          label: 'Tax progressivity',       min: 0.0,   max: 0.50,  step: 0.01,  default: 0.10,  type: 'range' },
+      { key: 'deficit_target',             label: 'Deficit target / GDP',   min: 0.0,   max: 0.15,  step: 0.01,  default: 0.03,  type: 'range', pct: true },
+      { key: 'deficit_adjustment_speed',   label: 'Deficit adj. speed',     min: 0.0,   max: 0.50,  step: 0.01,  default: 0.10,  type: 'range' },
+      { key: 'unemployment_benefit_ratio', label: 'Unemployment benefit',   min: 0.1,   max: 0.9,   step: 0.05,  default: 0.4,   type: 'range', pct: true },
+      { key: 'pension_ratio',              label: 'Pension ratio',          min: 0.1,   max: 0.8,   step: 0.05,  default: 0.3,   type: 'range', pct: true },
+    ],
+  },
+  {
+    label: 'Markets',
+    params: [
+      { key: 'price_adjustment_speed',    label: 'Goods price adj. speed',   min: 0.01,  max: 0.50,  step: 0.01,  default: 0.10,  type: 'range' },
+      { key: 'quantity_adjustment_speed', label: 'Quantity adj. speed',      min: 0.05,  max: 1.0,   step: 0.05,  default: 0.3,   type: 'range' },
+      { key: 'goods_search_intensity',    label: 'Goods search intensity',   min: 0.1,   max: 1.0,   step: 0.1,   default: 0.5,   type: 'range', pct: true },
+      { key: 'wage_stickiness',           label: 'Wage stickiness',          min: 0.0,   max: 1.0,   step: 0.05,  default: 0.8,   type: 'range', pct: true },
+      { key: 'matching_efficiency',       label: 'Labour matching eff.',     min: 0.05,  max: 1.0,   step: 0.05,  default: 0.3,   type: 'range', pct: true },
+      { key: 'separation_rate',           label: 'Job separation rate',      min: 0.01,  max: 0.20,  step: 0.01,  default: 0.05,  type: 'range', pct: true },
+      { key: 'phillips_curve_slope',      label: 'Phillips curve slope',     min: -2.0,  max: 0.0,   step: 0.1,   default: -0.5,  type: 'range' },
+      { key: 'collateral_requirement',    label: 'Collateral req.',          min: 0.0,   max: 1.0,   step: 0.05,  default: 0.5,   type: 'range', pct: true },
+      { key: 'default_rate_base',         label: 'Base default rate',        min: 0.0,   max: 0.10,  step: 0.005, default: 0.01,  type: 'range', pct: true },
     ],
   },
 ];
@@ -176,6 +217,10 @@ const state = {
   hasResults: false,
   params:     {},       // filled during init
 };
+
+// Defaults loaded from /api/defaults; fall back to PARAM_GROUPS defaults if
+// the fetch fails.
+let _apiDefaults = {};
 
 // ── DOM helpers ───────────────────────────────────────────────────────
 
@@ -208,6 +253,14 @@ function showSummary(periods) {
 
 // ── Build sidebar controls ─────────────────────────────────────────────
 
+function _resolveDefault(p) {
+  // Use API-loaded default if available; clamp to slider range.
+  if (_apiDefaults[p.key] !== undefined) {
+    return Math.max(p.min, Math.min(p.max, _apiDefaults[p.key]));
+  }
+  return p.default;
+}
+
 function buildSidebar() {
   const container = $('param-groups');
   container.innerHTML = '';
@@ -227,7 +280,9 @@ function buildSidebar() {
     body.className = 'param-group-body';
 
     group.params.forEach(p => {
-      state.params[p.key] = p.default;
+      const defVal = _resolveDefault(p);
+      state.params[p.key] = defVal;
+
       const row = document.createElement('div');
       row.className = 'param-row';
 
@@ -238,7 +293,7 @@ function buildSidebar() {
       const valSpan = document.createElement('span');
       valSpan.className = 'val';
       valSpan.id = `val-${p.key}`;
-      valSpan.textContent = fmtParamVal(p, p.default);
+      valSpan.textContent = fmtParamVal(p, defVal);
       labelRow.append(labelSpan, valSpan);
 
       const input = document.createElement('input');
@@ -246,7 +301,7 @@ function buildSidebar() {
       input.min   = p.min;
       input.max   = p.max;
       input.step  = p.step;
-      input.value = p.default;
+      input.value = defVal;
       input.id    = `input-${p.key}`;
 
       input.addEventListener('input', () => {
@@ -373,20 +428,34 @@ async function runSimulation() {
 function resetParams() {
   PARAM_GROUPS.forEach(group => {
     group.params.forEach(p => {
-      const input = $(`input-${p.key}`);
-      const val   = $(`val-${p.key}`);
+      const defVal = _resolveDefault(p);
+      const input  = $(`input-${p.key}`);
+      const val    = $(`val-${p.key}`);
       if (input) {
-        input.value = p.default;
-        state.params[p.key] = p.default;
+        input.value = defVal;
+        state.params[p.key] = defVal;
       }
-      if (val) val.textContent = fmtParamVal(p, p.default);
+      if (val) val.textContent = fmtParamVal(p, defVal);
     });
   });
 }
 
 // ── Init ──────────────────────────────────────────────────────────────
 
-function init() {
+async function init() {
+  setStatus('ready', 'Loading configuration…');
+
+  // Fetch defaults from the API; fall back to static values on failure.
+  try {
+    const resp = await fetch('/api/defaults');
+    if (resp.ok) {
+      const data = await resp.json();
+      _apiDefaults = data.params || {};
+    }
+  } catch (e) {
+    console.warn('Could not load defaults from API, using built-in values:', e);
+  }
+
   buildSidebar();
   buildCharts();
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,184 @@
+"""Tests for the economy simulator webapp models and parameter mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestSimulationParams:
+    """Tests for the expanded SimulationParams model."""
+
+    def test_default_construction(self) -> None:
+        from companies_house_abm.webapp.models import SimulationParams
+
+        p = SimulationParams()
+        assert p.periods == 80
+        assert p.seed == 42
+        assert p.n_firms == 100
+        assert p.n_households == 500
+        assert p.n_banks == 10
+
+    def test_all_new_fields_present(self) -> None:
+        from companies_house_abm.webapp.models import SimulationParams
+
+        p = SimulationParams()
+        # Firms behaviour
+        assert p.firm_entry_rate == pytest.approx(0.02)
+        assert p.firm_exit_threshold == pytest.approx(-0.5)
+        assert p.price_markup == pytest.approx(0.15)
+        assert p.markup_adjustment_speed == pytest.approx(0.10)
+        assert p.inventory_target_ratio == pytest.approx(0.20)
+        assert p.capacity_utilization_target == pytest.approx(0.85)
+        assert p.investment_sensitivity == pytest.approx(2.0)
+        assert p.wage_adjustment_speed == pytest.approx(0.05)
+        # Households
+        assert p.income_mean == pytest.approx(35_000.0)
+        assert p.income_std == pytest.approx(15_000.0)
+        assert p.wealth_shape == pytest.approx(1.5)
+        assert p.mpc_mean == pytest.approx(0.8)
+        assert p.mpc_std == pytest.approx(0.1)
+        assert p.job_search_intensity == pytest.approx(0.3)
+        assert p.reservation_wage_ratio == pytest.approx(0.9)
+        assert p.consumption_smoothing == pytest.approx(0.7)
+        # Banks
+        assert p.capital_requirement == pytest.approx(0.10)
+        assert p.reserve_requirement == pytest.approx(0.01)
+        assert p.base_interest_markup == pytest.approx(0.02)
+        assert p.risk_premium_sensitivity == pytest.approx(0.05)
+        assert p.lending_threshold == pytest.approx(0.3)
+        assert p.capital_buffer == pytest.approx(0.02)
+        # Central bank
+        assert p.inflation_target == pytest.approx(0.02)
+        assert p.inflation_coefficient == pytest.approx(1.5)
+        assert p.output_gap_coefficient == pytest.approx(0.5)
+        assert p.interest_rate_smoothing == pytest.approx(0.8)
+        assert p.lower_bound == pytest.approx(0.001)
+        # Government
+        assert p.spending_gdp_ratio == pytest.approx(0.40)
+        assert p.corporate_tax_rate == pytest.approx(0.19)
+        assert p.income_tax_rate == pytest.approx(0.20)
+        assert p.tax_progressivity == pytest.approx(0.10)
+        assert p.deficit_target == pytest.approx(0.03)
+        assert p.deficit_adjustment_speed == pytest.approx(0.10)
+        # Transfers
+        assert p.unemployment_benefit_ratio == pytest.approx(0.4)
+        assert p.pension_ratio == pytest.approx(0.3)
+        # Goods market
+        assert p.price_adjustment_speed == pytest.approx(0.1)
+        assert p.quantity_adjustment_speed == pytest.approx(0.3)
+        assert p.goods_search_intensity == pytest.approx(0.5)
+        # Labour market
+        assert p.wage_stickiness == pytest.approx(0.8)
+        assert p.matching_efficiency == pytest.approx(0.3)
+        assert p.separation_rate == pytest.approx(0.05)
+        assert p.phillips_curve_slope == pytest.approx(-0.5)
+        # Credit market
+        assert p.collateral_requirement == pytest.approx(0.5)
+        assert p.default_rate_base == pytest.approx(0.01)
+
+    def test_validation_rejects_out_of_range(self) -> None:
+        from pydantic import ValidationError
+
+        from companies_house_abm.webapp.models import SimulationParams
+
+        with pytest.raises(ValidationError):
+            SimulationParams(periods=5)  # below ge=10
+
+        with pytest.raises(ValidationError):
+            SimulationParams(n_firms=5)  # below ge=10
+
+        with pytest.raises(ValidationError):
+            SimulationParams(phillips_curve_slope=1.0)  # above le=0.0
+
+
+class TestConfigToParams:
+    """Tests for _config_to_params helper."""
+
+    def test_roundtrip_default_config(self) -> None:
+        """Config → params → config should preserve all values."""
+        from companies_house_abm.abm.config import load_config
+        from companies_house_abm.webapp.app import _config_to_params, _params_to_config
+
+        cfg = load_config()
+        params = _config_to_params(cfg)
+        cfg2 = _params_to_config(params)
+
+        # Economic parameters should survive the round-trip
+        assert cfg2.firm_behavior.price_markup == pytest.approx(
+            cfg.firm_behavior.price_markup
+        )
+        assert cfg2.taylor_rule.inflation_target == pytest.approx(
+            cfg.taylor_rule.inflation_target
+        )
+        assert cfg2.fiscal_rule.tax_rate_corporate == pytest.approx(
+            cfg.fiscal_rule.tax_rate_corporate
+        )
+        assert cfg2.labor_market.wage_stickiness == pytest.approx(
+            cfg.labor_market.wage_stickiness
+        )
+        assert cfg2.credit_market.collateral_requirement == pytest.approx(
+            cfg.credit_market.collateral_requirement
+        )
+
+    def test_clamping_of_large_sample_size(self) -> None:
+        """Values exceeding Pydantic bounds are clamped, not rejected."""
+        import dataclasses
+
+        from companies_house_abm.abm.config import FirmConfig, ModelConfig, load_config
+        from companies_house_abm.webapp.app import _config_to_params
+
+        cfg = load_config()
+        # Patch in an oversized sample_size
+        oversized = dataclasses.replace(
+            cfg, firms=dataclasses.replace(cfg.firms, sample_size=999_999)
+        )
+        params = _config_to_params(oversized)
+        assert params.n_firms <= 100_000
+
+    def test_non_model_config_returns_defaults(self) -> None:
+        from companies_house_abm.webapp.app import _config_to_params
+        from companies_house_abm.webapp.models import SimulationParams
+
+        result = _config_to_params("not a config")
+        assert isinstance(result, SimulationParams)
+        assert result.periods == 80  # Pydantic default
+
+
+class TestParamsToConfig:
+    """Tests for _params_to_config helper."""
+
+    def test_all_sub_configs_populated(self) -> None:
+        from companies_house_abm.abm.config import ModelConfig
+        from companies_house_abm.webapp.app import _params_to_config
+        from companies_house_abm.webapp.models import SimulationParams
+
+        params = SimulationParams(
+            periods=40,
+            n_firms=50,
+            n_households=200,
+            corporate_tax_rate=0.25,
+            inflation_target=0.03,
+            wage_stickiness=0.6,
+        )
+        cfg = _params_to_config(params)
+        assert isinstance(cfg, ModelConfig)
+        assert cfg.simulation.periods == 40
+        assert cfg.firms.sample_size == 50
+        assert cfg.households.count == 200
+        assert cfg.fiscal_rule.tax_rate_corporate == pytest.approx(0.25)
+        assert cfg.taylor_rule.inflation_target == pytest.approx(0.03)
+        assert cfg.labor_market.wage_stickiness == pytest.approx(0.6)
+
+    def test_markets_wired_correctly(self) -> None:
+        from companies_house_abm.webapp.app import _params_to_config
+        from companies_house_abm.webapp.models import SimulationParams
+
+        params = SimulationParams(
+            goods_search_intensity=0.7,
+            collateral_requirement=0.3,
+            default_rate_base=0.02,
+        )
+        cfg = _params_to_config(params)
+        assert cfg.goods_market.search_intensity == pytest.approx(0.7)
+        assert cfg.credit_market.collateral_requirement == pytest.approx(0.3)
+        assert cfg.credit_market.default_rate_base == pytest.approx(0.02)


### PR DESCRIPTION
Expands SimulationParams from 14 to 48 fields; GET /api/defaults loads from YAML config.