### PR TITLE
feat(analysis): add company financial analysis, forecasting, and sector comparison

### DIFF
--- a/src/companies_house_abm/company_analysis.py
+++ b/src/companies_house_abm/company_analysis.py
@@ -1,0 +1,1169 @@
+"""Company financial analysis and forecasting from Companies House XBRL data.
+
+Usage
+-----
+>>> from companies_house_abm.company_analysis import generate_report
+>>> print(generate_report("Exel Computer Systems"))
+
+CLI
+---
+    uv run python -m companies_house_abm.company_analysis "Exel Computer Systems"
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+from scipy import stats
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def _find_default_parquet() -> Path:
+    """Walk up from this file to find data/companies_house_accounts.parquet."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "data" / "companies_house_accounts.parquet"
+        if candidate.exists():
+            return candidate
+    # Fall back to a path relative to cwd
+    return Path("data") / "companies_house_accounts.parquet"
+
+
+_DEFAULT_PARQUET = _find_default_parquet()
+
+# ---------------------------------------------------------------------------
+# Constants: which columns belong to which financial statement
+# ---------------------------------------------------------------------------
+
+_PL_COLS = [
+    "turnover_gross_operating_revenue",
+    "other_operating_income",
+    "cost_sales",
+    "gross_profit_loss",
+    "administrative_expenses",
+    "raw_materials_consumables",
+    "staff_costs",
+    "depreciation_other_amounts_written_off_tangible_intangible_fixed_assets",
+    "operating_profit_loss",
+    "profit_loss_on_ordinary_activities_before_tax",
+    "tax_on_profit_or_loss_on_ordinary_activities",
+    "profit_loss_for_period",
+]
+
+_BS_COLS = [
+    "tangible_fixed_assets",
+    "debtors",
+    "cash_bank_in_hand",
+    "current_assets",
+    "creditors_due_within_one_year",
+    "creditors_due_after_one_year",
+    "net_current_assets_liabilities",
+    "total_assets_less_current_liabilities",
+    "net_assets_liabilities_including_pension_asset_liability",
+    "called_up_share_capital",
+    "profit_loss_account_reserve",
+    "shareholder_funds",
+    "average_number_employees_during_period",
+]
+
+# XBRL instant facts have period_start == period_end; duration facts differ.
+_INSTANT_THRESHOLD_DAYS = 5  # allow minor rounding in XBRL filings
+
+
+# ---------------------------------------------------------------------------
+# Data-classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ForecastResult:
+    """Linear trend forecast for a single metric."""
+
+    metric: str
+    display_name: str
+    historical_years: list[int]
+    historical_values: list[float]
+    forecast_years: list[int]
+    forecast_values: list[float]
+    slope: float  # £ per year
+    r_squared: float
+    trend_direction: str  # "improving", "declining", "flat"
+    confidence_note: str
+
+
+@dataclass
+class CompanyReport:
+    """Structured output of a company analysis."""
+
+    company_name: str
+    company_id: str
+    num_periods: int
+    pl_history: pl.DataFrame  # one row per accounting period
+    bs_history: pl.DataFrame  # one row per balance-sheet date
+    forecasts: list[ForecastResult] = field(default_factory=list)
+    report_text: str = ""
+    sector_benchmark: SectorBenchmark | None = None
+
+
+@dataclass
+class SectorBenchmark:
+    """Peer-group comparison for a company's key margin metrics.
+
+    Peers are companies with revenue in [target_revenue / revenue_factor,
+    target_revenue * revenue_factor] that filed accounts in the same year
+    window.  When a SIC code lookup is provided the peer group is further
+    restricted to companies in the same 13-sector ABM taxonomy bucket.
+
+    All margins are expressed as percentages (e.g. 37.4 means 37.4 %).
+    The revenue-weighted averages give more weight to larger companies,
+    consistent with standard value-weighted sector-index methodology.
+    """
+
+    sector_label: str
+    """Human-readable description of the peer group."""
+    n_peers: int
+    """Number of peer companies contributing to the benchmarks."""
+    year: int
+    """Fiscal year used for the comparison (target company's latest P&L year)."""
+    peer_revenue_low: float
+    """Lowest revenue in the peer group (£)."""
+    peer_revenue_high: float
+    """Highest revenue in the peer group (£)."""
+    company_revenue: float | None = None
+    """Target company revenue in the comparison year (£)."""
+    # Revenue-weighted sector averages
+    wt_gross_margin_pct: float | None = None
+    wt_operating_margin_pct: float | None = None
+    wt_net_margin_pct: float | None = None
+    # Unweighted quartile distributions: (p25, p50, p75)
+    gross_margin_quartiles: tuple[float, float, float] | None = None
+    operating_margin_quartiles: tuple[float, float, float] | None = None
+    net_margin_quartiles: tuple[float, float, float] | None = None
+    # Company's own values and percentile rank within the peer distribution
+    company_gross_margin_pct: float | None = None
+    company_gross_margin_percentile: float | None = None
+    company_operating_margin_pct: float | None = None
+    company_operating_margin_percentile: float | None = None
+    company_net_margin_pct: float | None = None
+    company_net_margin_percentile: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Search helpers
+# ---------------------------------------------------------------------------
+
+
+def search_companies(
+    name: str,
+    parquet_path: Path | None = None,
+    *,
+    max_results: int = 20,
+) -> pl.DataFrame:
+    """Return distinct companies whose name contains *name* (case-insensitive).
+
+    Parameters
+    ----------
+    name:
+        Search string - matched as a substring against ``entity_current_legal_name``.
+    parquet_path:
+        Path to the processed Companies House parquet.  Defaults to
+        ``data/companies_house_accounts.parquet`` relative to the repo root.
+    max_results:
+        Cap on number of rows returned.
+    """
+    path = Path(parquet_path) if parquet_path else _DEFAULT_PARQUET
+    return (
+        pl.scan_parquet(path)
+        .filter(
+            pl.col("entity_current_legal_name")
+            .str.to_lowercase()
+            .str.contains(name.lower())
+        )
+        .select(["company_id", "entity_current_legal_name"])
+        .unique()
+        .sort("entity_current_legal_name")
+        .head(max_results)
+        .collect()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data loading & reshaping
+# ---------------------------------------------------------------------------
+
+
+def load_company_data(
+    company_id: str,
+    parquet_path: Path | None = None,
+) -> pl.DataFrame:
+    """Load every row for *company_id* from the parquet."""
+    path = Path(parquet_path) if parquet_path else _DEFAULT_PARQUET
+    return pl.scan_parquet(path).filter(pl.col("company_id") == company_id).collect()
+
+
+def _is_instant(df: pl.DataFrame) -> pl.Series:
+    """Boolean mask: True for balance-sheet (instant) rows."""
+    diff = (pl.col("period_end") - pl.col("period_start")).dt.total_days()
+    return df.select(diff.alias("d"))["d"].abs() <= _INSTANT_THRESHOLD_DAYS
+
+
+def split_statements(df: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Split raw company rows into (P&L duration rows, balance-sheet instant rows)."""
+    mask = _is_instant(df)
+    bs = df.filter(mask)
+    pl_ = df.filter(~mask)
+    return pl_, bs
+
+
+def build_pl_history(pl_df: pl.DataFrame) -> pl.DataFrame:
+    """Return a clean annual P&L time-series sorted by period_end."""
+    if pl_df.is_empty():
+        return pl_df
+    cols = ["period_start", "period_end"] + [c for c in _PL_COLS if c in pl_df.columns]
+    return (
+        pl_df.select(cols)
+        .sort("period_end")
+        .with_columns(
+            pl.col(c).cast(pl.Float64) for c in _PL_COLS if c in pl_df.columns
+        )
+    )
+
+
+def build_bs_history(bs_df: pl.DataFrame) -> pl.DataFrame:
+    """Return a clean balance-sheet snapshot time-series sorted by period_end."""
+    if bs_df.is_empty():
+        return bs_df
+    cols = ["period_end"] + [c for c in _BS_COLS if c in bs_df.columns]
+    return (
+        bs_df.select(cols)
+        .sort("period_end")
+        .with_columns(
+            pl.col(c).cast(pl.Float64)
+            for c in _BS_COLS
+            if c in bs_df.columns and c != "average_number_employees_during_period"
+        )
+        .with_columns(
+            pl.col("average_number_employees_during_period").cast(pl.Float64)
+            if "average_number_employees_during_period" in bs_df.columns
+            else pl.lit(None, dtype=pl.Float64).alias(
+                "average_number_employees_during_period"
+            )
+        )
+    )
+
+
+def compute_derived_metrics(
+    pl_hist: pl.DataFrame,
+    bs_hist: pl.DataFrame,
+) -> pl.DataFrame:
+    """Merge P&L and balance-sheet data and add derived financial ratios."""
+    if pl_hist.is_empty():
+        return pl_hist
+
+    df = pl_hist
+    bs = bs_hist.rename({"period_end": "bs_date"}) if not bs_hist.is_empty() else None
+
+    # Attach balance-sheet figures where period_end matches a balance-sheet instant date
+    if bs is not None and not bs.is_empty():
+        df = df.join_asof(
+            bs.sort("bs_date"),
+            left_on="period_end",
+            right_on="bs_date",
+            strategy="nearest",
+            tolerance="60d",
+        )
+
+    # Derived ratios (safely handle division by zero / nulls)
+    def safe_ratio(num: str, den: str, alias: str) -> pl.Expr:
+        return (
+            pl.when(pl.col(den).is_not_null() & (pl.col(den) != 0))
+            .then(pl.col(num) / pl.col(den) * 100)
+            .otherwise(None)
+            .alias(alias)
+        ).cast(pl.Float64)
+
+    rev_col = "turnover_gross_operating_revenue"
+    exprs = []
+    if "gross_profit_loss" in df.columns and rev_col in df.columns:
+        exprs.append(safe_ratio("gross_profit_loss", rev_col, "gross_margin_pct"))
+    if "operating_profit_loss" in df.columns and rev_col in df.columns:
+        exprs.append(
+            safe_ratio("operating_profit_loss", rev_col, "operating_margin_pct")
+        )
+    if "profit_loss_for_period" in df.columns and rev_col in df.columns:
+        exprs.append(safe_ratio("profit_loss_for_period", rev_col, "net_margin_pct"))
+
+    if exprs:
+        df = df.with_columns(exprs)
+
+    # YoY revenue growth
+    if "turnover_gross_operating_revenue" in df.columns and len(df) > 1:
+        df = df.with_columns(
+            (
+                pl.col("turnover_gross_operating_revenue")
+                / pl.col("turnover_gross_operating_revenue").shift(1)
+                - 1
+            ).alias("revenue_yoy_growth_pct")
+            * 100
+        )
+
+    return df.sort("period_end")
+
+
+def build_peer_group(
+    target_revenue: float,
+    target_year: int,
+    parquet_path: Path,
+    *,
+    revenue_factor: float = 4.0,
+    year_window: int = 1,
+    sector_company_ids: frozenset[str] | None = None,
+    exclude_company_id: str | None = None,
+    max_peers: int = 10_000,
+) -> pl.DataFrame:
+    """Return one P&L row per peer company for sector benchmarking.
+
+    Parameters
+    ----------
+    target_revenue:
+        Target company revenue (£).  Used to compute the size band
+        ``[target_revenue / revenue_factor, target_revenue * revenue_factor]``.
+    target_year:
+        Target company's most recent P&L year.  Peers are accepted for years
+        in ``[target_year - year_window, target_year + year_window]``.
+    parquet_path:
+        Path to the Companies House accounts parquet.
+    revenue_factor:
+        Half-width multiplier for the revenue band (default 4x, i.e. 1/4x to 4x).
+    year_window:
+        ± years from *target_year* to search (default 1).
+    sector_company_ids:
+        If supplied, restrict to this set of Companies House numbers (e.g.
+        derived from a SIC-code lookup).
+    exclude_company_id:
+        Exclude the target company itself from the peer group.
+    max_peers:
+        Hard cap on the number of peers returned.
+
+    Returns
+    -------
+    pl.DataFrame
+        Columns: ``company_id``, ``period_end``,
+        ``turnover_gross_operating_revenue``, ``gross_profit_loss``,
+        ``operating_profit_loss``, ``profit_loss_for_period``.
+        One row per peer (most recent qualifying period).
+    """
+    low = target_revenue / revenue_factor
+    high = target_revenue * revenue_factor
+    year_low = target_year - year_window
+    year_high = target_year + year_window
+
+    lf = (
+        pl.scan_parquet(parquet_path)
+        # Duration rows only (P&L, not balance-sheet instants)
+        .filter(
+            (pl.col("period_end") - pl.col("period_start")).dt.total_days().abs()
+            > _INSTANT_THRESHOLD_DAYS
+        )
+        # Year range
+        .filter(pl.col("period_end").dt.year().is_between(year_low, year_high))
+        # Revenue band — also drops nulls
+        .filter(
+            pl.col("turnover_gross_operating_revenue").is_not_null()
+            & pl.col("turnover_gross_operating_revenue").is_between(low, high)
+        )
+        .select(
+            [
+                "company_id",
+                "period_end",
+                "turnover_gross_operating_revenue",
+                "gross_profit_loss",
+                "operating_profit_loss",
+                "profit_loss_for_period",
+            ]
+        )
+    )
+
+    if sector_company_ids is not None:
+        lf = lf.filter(pl.col("company_id").is_in(list(sector_company_ids)))
+
+    if exclude_company_id is not None:
+        lf = lf.filter(pl.col("company_id") != exclude_company_id)
+
+    # One row per company: keep the most recent period
+    lf = lf.sort("period_end", descending=True).unique(
+        subset=["company_id"], keep="first"
+    )
+
+    df = lf.collect()
+    if len(df) > max_peers:
+        df = df.head(max_peers)
+    return df
+
+
+def _load_sic_sector_ids(
+    sic_path: Path,
+    company_id: str,
+) -> tuple[str | None, frozenset[str] | None]:
+    """Look up *company_id* in a SIC code file and return its sector + co-sector IDs.
+
+    The SIC file must have columns ``companies_house_registered_number`` (or
+    ``company_number`` / similar) and ``sic_code``.  Both parquet and CSV are
+    accepted.
+
+    Returns
+    -------
+    (sector_name, frozenset_of_company_ids)
+        ``sector_name`` is the ABM 13-sector label (e.g. ``"technology"``).
+        Returns ``(None, None)`` if the lookup fails for any reason.
+    """
+    from companies_house_abm.data_sources.firm_distributions import SIC_TO_SECTOR
+
+    try:
+        p = Path(sic_path)
+        if p.suffix == ".parquet":
+            sic_df = pl.read_parquet(p)
+        else:
+            sic_df = pl.read_csv(p, infer_schema_length=2000)
+    except Exception:
+        logger.warning("Could not read SIC code file: %s", sic_path, exc_info=True)
+        return None, None
+
+    # Normalise column names
+    rename: dict[str, str] = {}
+    for col in sic_df.columns:
+        cl = col.lower()
+        if any(
+            kw in cl for kw in ("registered_number", "company_number", "company_id")
+        ):
+            rename[col] = "_cid"
+        elif "sic" in cl:
+            rename[col] = "_sic"
+    if "_cid" not in rename.values() or "_sic" not in rename.values():
+        return None, None
+    sic_df = sic_df.rename(rename)
+
+    sic_df = sic_df.with_columns(
+        [
+            pl.col("_cid").cast(pl.Utf8).str.zfill(8),
+            pl.col("_sic").cast(pl.Utf8).str.strip_chars(),
+        ]
+    )
+
+    target_rows = sic_df.filter(pl.col("_cid") == company_id)
+    if target_rows.is_empty():
+        return None, None
+
+    sic_code = str(target_rows["_sic"][0]).strip()
+    division = sic_code[:2]
+    sector = SIC_TO_SECTOR.get(division)
+    if sector is None:
+        return None, None
+
+    # All divisions that map to the same sector
+    same_sector_divs = {k for k, v in SIC_TO_SECTOR.items() if v == sector}
+    sector_ids = frozenset(
+        sic_df.filter(pl.col("_sic").str.slice(0, 2).is_in(same_sector_divs))[
+            "_cid"
+        ].to_list()
+    )
+    return sector, sector_ids
+
+
+def compute_sector_benchmark(
+    peers: pl.DataFrame,
+    company_revenue: float,
+    company_gross_margin: float | None,
+    company_op_margin: float | None,
+    company_net_margin: float | None,
+    sector_label: str,
+    target_year: int,
+) -> SectorBenchmark | None:
+    """Compute revenue-weighted benchmarks from a peer DataFrame.
+
+    Returns ``None`` if the peer group is empty or has no valid margin data.
+
+    Parameters
+    ----------
+    peers:
+        Output of :func:`build_peer_group`.
+    company_revenue:
+        Target company revenue (for metadata).
+    company_gross_margin, company_op_margin, company_net_margin:
+        Target company margin values (%) for percentile positioning.
+    sector_label:
+        Human-readable peer-group description for display.
+    target_year:
+        Fiscal year label.
+    """
+    rev_col = "turnover_gross_operating_revenue"
+
+    if peers.is_empty():
+        return None
+
+    # Compute margins per peer, drop rows with zero/null revenue
+    df = peers.filter(
+        pl.col(rev_col).is_not_null() & (pl.col(rev_col) > 0)
+    ).with_columns(
+        [
+            (pl.col("gross_profit_loss") / pl.col(rev_col) * 100).alias("_gm"),
+            (pl.col("operating_profit_loss") / pl.col(rev_col) * 100).alias("_om"),
+            (pl.col("profit_loss_for_period") / pl.col(rev_col) * 100).alias("_nm"),
+        ]
+    )
+
+    if df.is_empty():
+        return None
+
+    revenues = df[rev_col].cast(pl.Float64).to_numpy()
+
+    def _weighted_avg(margin_col: str) -> float | None:
+        vals = df[margin_col].cast(pl.Float64).to_numpy()
+        mask = ~np.isnan(vals) & (revenues > 0)
+        if mask.sum() < 2:
+            return None
+        return float(np.average(vals[mask], weights=revenues[mask]))
+
+    def _quartiles(margin_col: str) -> tuple[float, float, float] | None:
+        arr = df[margin_col].drop_nulls().cast(pl.Float64).to_numpy()
+        arr = arr[~np.isnan(arr)]
+        if len(arr) < 4:
+            return None
+        return (
+            float(np.percentile(arr, 25)),
+            float(np.percentile(arr, 50)),
+            float(np.percentile(arr, 75)),
+        )
+
+    def _pct_rank(margin_col: str, company_val: float | None) -> float | None:
+        if company_val is None or np.isnan(company_val):
+            return None
+        arr = df[margin_col].drop_nulls().cast(pl.Float64).to_numpy()
+        arr = arr[~np.isnan(arr)]
+        if len(arr) < 2:
+            return None
+        return float(stats.percentileofscore(arr, company_val, kind="mean"))
+
+    return SectorBenchmark(
+        sector_label=sector_label,
+        n_peers=len(df),
+        year=target_year,
+        peer_revenue_low=float(df[rev_col].min()),
+        peer_revenue_high=float(df[rev_col].max()),
+        company_revenue=company_revenue,
+        wt_gross_margin_pct=_weighted_avg("_gm"),
+        wt_operating_margin_pct=_weighted_avg("_om"),
+        wt_net_margin_pct=_weighted_avg("_nm"),
+        gross_margin_quartiles=_quartiles("_gm"),
+        operating_margin_quartiles=_quartiles("_om"),
+        net_margin_quartiles=_quartiles("_nm"),
+        company_gross_margin_pct=company_gross_margin,
+        company_gross_margin_percentile=_pct_rank("_gm", company_gross_margin),
+        company_operating_margin_pct=company_op_margin,
+        company_operating_margin_percentile=_pct_rank("_om", company_op_margin),
+        company_net_margin_pct=company_net_margin,
+        company_net_margin_percentile=_pct_rank("_nm", company_net_margin),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Forecasting
+# ---------------------------------------------------------------------------
+
+
+def _trend_direction(slope: float, scale: float) -> str:
+    if scale == 0:
+        return "flat"
+    rel = slope / abs(scale)
+    if rel > 0.02:
+        return "improving"
+    if rel < -0.02:
+        return "declining"
+    return "flat"
+
+
+def forecast_metric(
+    years: list[int],
+    values: list[float],
+    metric: str,
+    display_name: str,
+    horizon: int = 3,
+) -> ForecastResult | None:
+    """Fit a linear trend and project *horizon* years ahead.
+
+    Returns ``None`` if fewer than 2 non-null data points are available.
+    """
+    # Filter out NaN/None
+    clean = [
+        (y, v)
+        for y, v in zip(years, values, strict=False)
+        if v is not None and not np.isnan(v)
+    ]
+    if len(clean) < 2:
+        return None
+
+    xs = np.array([c[0] for c in clean], dtype=float)
+    ys = np.array([c[1] for c in clean], dtype=float)
+
+    slope, intercept, r_value, _p, _se = stats.linregress(xs, ys)
+    r_squared = r_value**2
+
+    last_year = round(xs[-1])
+    forecast_years = list(range(last_year + 1, last_year + horizon + 1))
+    forecast_values = [float(slope * y + intercept) for y in forecast_years]
+
+    n_obs = len(clean)
+    if n_obs < 3:
+        confidence_note = (
+            f"Low confidence: only {n_obs} data point(s) — treat as indicative only."
+        )
+    elif r_squared < 0.5:
+        confidence_note = f"Moderate confidence: R²={r_squared:.2f} — trend is noisy."
+    else:
+        confidence_note = f"Good fit: R²={r_squared:.2f}."
+
+    return ForecastResult(
+        metric=metric,
+        display_name=display_name,
+        historical_years=[round(y) for y in xs],
+        historical_values=ys.tolist(),
+        forecast_years=forecast_years,
+        forecast_values=forecast_values,
+        slope=float(slope),
+        r_squared=r_squared,
+        trend_direction=_trend_direction(slope, float(np.mean(np.abs(ys)))),
+        confidence_note=confidence_note,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+_METRIC_LABELS: dict[str, str] = {
+    "turnover_gross_operating_revenue": "Revenue",
+    "gross_profit_loss": "Gross Profit",
+    "operating_profit_loss": "Operating Profit",
+    "profit_loss_for_period": "Net Profit",
+    "cost_sales": "Cost of Sales",
+    "administrative_expenses": "Admin Expenses",
+    "staff_costs": "Staff Costs",
+    "current_assets": "Current Assets",
+    "debtors": "Debtors",
+    "creditors_due_within_one_year": "Creditors (< 1yr)",
+    "creditors_due_after_one_year": "Creditors (> 1yr)",
+    "net_current_assets_liabilities": "Net Current Assets",
+    "total_assets_less_current_liabilities": "Total Assets less CL",
+    "net_assets_liabilities_including_pension_asset_liability": "Net Assets",
+    "shareholder_funds": "Shareholder Funds",
+    "cash_bank_in_hand": "Cash",
+    "tangible_fixed_assets": "Tangible Fixed Assets",
+    "average_number_employees_during_period": "Employees",
+    "gross_margin_pct": "Gross Margin %",
+    "operating_margin_pct": "Operating Margin %",
+    "net_margin_pct": "Net Margin %",
+}
+
+
+def _ordinal(n: int) -> str:
+    """Return ordinal string for integer (1→'1st', 72→'72nd', etc.)."""
+    if 11 <= (n % 100) <= 13:
+        suffix = "th"
+    else:
+        suffix = {1: "st", 2: "nd", 3: "rd"}.get(n % 10, "th")
+    return f"{n}{suffix}"
+
+
+def _fmt(v: float | None, is_pct: bool = False, is_headcount: bool = False) -> str:
+    if v is None or (isinstance(v, float) and np.isnan(v)):
+        return "n/a"
+    if is_headcount:
+        return f"{round(v):,}"
+    if is_pct:
+        return f"{v:.1f}%"
+    if abs(v) >= 1_000_000:
+        return f"£{v / 1_000_000:.2f}m"
+    if abs(v) >= 1_000:
+        return f"£{v / 1_000:.1f}k"
+    return f"£{v:.0f}"
+
+
+def _section(title: str, width: int = 70) -> str:
+    return f"\n{'─' * width}\n{title}\n{'─' * width}"
+
+
+def _build_report_text(report: CompanyReport) -> str:
+    lines: list[str] = []
+    lines.append("=" * 70)
+    lines.append("  COMPANY FINANCIAL REPORT")
+    lines.append(f"  {report.company_name}  (Companies House ID: {report.company_id})")
+    lines.append("=" * 70)
+
+    pl_hist = report.pl_history
+    bs_hist = report.bs_history
+
+    # ── Overview ──────────────────────────────────────────────────────────
+    lines.append(_section("OVERVIEW"))
+    if not pl_hist.is_empty():
+        first_year = pl_hist["period_end"][0].year
+        last_year = pl_hist["period_end"][-1].year
+        lines.append(f"  P&L periods covered : {first_year} - {last_year}")
+        lines.append(f"  Accounting periods  : {len(pl_hist)}")
+    if not bs_hist.is_empty():
+        lines.append(f"  Balance-sheet dates : {len(bs_hist)}")
+    if pl_hist.is_empty() and bs_hist.is_empty():
+        lines.append("  No financial data found for this company.")
+        return "\n".join(lines)
+
+    # ── P&L History ───────────────────────────────────────────────────────
+    if not pl_hist.is_empty():
+        lines.append(_section("PROFIT & LOSS HISTORY"))
+        header_cols = [
+            ("Period End", 12),
+            ("Revenue", 12),
+            ("Gross Profit", 13),
+            ("Op. Profit", 12),
+            ("Net Profit", 12),
+            ("Gross Margin", 13),
+            ("Op. Margin", 11),
+        ]
+        header = "  " + "".join(f"{h:<{w}}" for h, w in header_cols)
+        lines.append(header)
+        lines.append("  " + "-" * (sum(w for _, w in header_cols)))
+        for row in pl_hist.iter_rows(named=True):
+            pe = str(row["period_end"])
+            rev = _fmt(row.get("turnover_gross_operating_revenue"))
+            gp = _fmt(row.get("gross_profit_loss"))
+            op = _fmt(row.get("operating_profit_loss"))
+            np_ = _fmt(row.get("profit_loss_for_period"))
+            gm = _fmt(row.get("gross_margin_pct"), is_pct=True)
+            om = _fmt(row.get("operating_margin_pct"), is_pct=True)
+            lines.append(
+                f"  {pe:<12}{rev:<12}{gp:<13}{op:<12}{np_:<12}{gm:<13}{om:<11}"
+            )
+
+        # YoY growth
+        if "revenue_yoy_growth_pct" in pl_hist.columns and len(pl_hist) > 1:
+            lines.append("")
+            lines.append("  Revenue YoY growth:")
+            for row in pl_hist.iter_rows(named=True):
+                g = row.get("revenue_yoy_growth_pct")
+                if g is not None and not np.isnan(g):
+                    arrow = "▲" if g >= 0 else "▼"
+                    lines.append(f"    {row['period_end']}: {arrow} {abs(g):.1f}%")
+
+    # ── Balance Sheet History ─────────────────────────────────────────────
+    if not bs_hist.is_empty():
+        lines.append(_section("BALANCE SHEET HISTORY"))
+        bs_display = [
+            ("current_assets", False, False),
+            ("cash_bank_in_hand", False, False),
+            ("debtors", False, False),
+            ("creditors_due_within_one_year", False, False),
+            ("net_current_assets_liabilities", False, False),
+            ("shareholder_funds", False, False),
+            ("average_number_employees_during_period", False, True),
+        ]
+        # Build header from available dates
+        dates = [str(r["period_end"]) for r in bs_hist.iter_rows(named=True)]
+        date_col_w = 13
+        label_w = 42
+        hdr = f"  {'Metric':<{label_w}}" + "".join(f"{d:<{date_col_w}}" for d in dates)
+        lines.append(hdr)
+        lines.append("  " + "-" * (label_w + date_col_w * len(dates)))
+        for col, is_pct, is_head in bs_display:
+            if col not in bs_hist.columns:
+                continue
+            label = _METRIC_LABELS.get(col, col)
+            row_vals = []
+            for row in bs_hist.iter_rows(named=True):
+                row_vals.append(_fmt(row.get(col), is_pct=is_pct, is_headcount=is_head))
+            row_str = "".join(f"{v:<{date_col_w}}" for v in row_vals)
+            lines.append(f"  {label:<{label_w}}" + row_str)
+
+    # ── Sector Comparison ─────────────────────────────────────────────────
+    if report.sector_benchmark is not None:
+        lines.extend(_format_sector_section(report.sector_benchmark))
+
+    # ── Forecasts ─────────────────────────────────────────────────────────
+    if report.forecasts:
+        lines.append(_section("FORECASTS (LINEAR TREND EXTRAPOLATION)"))
+        for fc in report.forecasts:
+            direction_sym = {"improving": "▲", "declining": "▼", "flat": "→"}[
+                fc.trend_direction
+            ]
+            lines.append(f"\n  {fc.display_name}  {direction_sym}")
+            is_pct_metric = "pct" in fc.metric
+            slope_str = f"{fc.slope:+.2f}pp" if is_pct_metric else f"{fc.slope:+,.0f}"
+            lines.append(f"  Trend: {slope_str} per year | {fc.confidence_note}")
+            is_m_pct = "pct" in fc.metric
+            # Historical
+            lines.append("  Historical:")
+            for y, v in zip(fc.historical_years, fc.historical_values, strict=False):
+                lines.append(f"    {y}: {_fmt(v, is_pct=is_m_pct)}")
+            # Forecast
+            lines.append("  Forecast:")
+            for y, v in zip(fc.forecast_years, fc.forecast_values, strict=False):
+                lines.append(f"    {y}: {_fmt(v, is_pct=is_m_pct)} (projected)")
+
+    # ── Narrative Summary ─────────────────────────────────────────────────
+    lines.append(_section("NARRATIVE SUMMARY"))
+    _write_narrative(lines, report)
+
+    lines.append("\n" + "=" * 70)
+    lines.append("  NOTE: Forecast uses simple linear regression on available data.")
+    if report.num_periods < 3:
+        lines.append(
+            f"  Only {report.num_periods} accounting period(s) found in the dataset — "
+            "projections are highly uncertain."
+        )
+    lines.append("=" * 70 + "\n")
+
+    return "\n".join(lines)
+
+
+def _write_narrative(lines: list[str], report: CompanyReport) -> None:
+    pl_hist = report.pl_history
+    if pl_hist.is_empty():
+        lines.append("  Insufficient P&L data available for narrative analysis.")
+        return
+
+    latest = pl_hist.row(-1, named=True)
+    rev = latest.get("turnover_gross_operating_revenue")
+    op = latest.get("operating_profit_loss")
+    gm = latest.get("gross_margin_pct")
+    om = latest.get("operating_margin_pct")
+
+    lines.append(
+        f"  In its most recent reported period (ending {latest['period_end']}),"
+    )
+    if rev:
+        lines.append(f"  {report.company_name} reported revenue of {_fmt(rev)},")
+    if op:
+        profitability = "profitable" if op > 0 else "loss-making"
+        lines.append(
+            f"  with an operating profit of {_fmt(op)} ({profitability} at the"
+            " operating level)."
+        )
+    if gm:
+        lines.append(
+            f"  Gross margin: {gm:.1f}%  |  Operating margin: {_fmt(om, is_pct=True)}"
+        )
+
+    # Trend commentary
+    rev_metric = "turnover_gross_operating_revenue"
+    revenue_fcs = [f for f in report.forecasts if f.metric == rev_metric]
+    if revenue_fcs:
+        fc = revenue_fcs[0]
+        lines.append("")
+        if fc.trend_direction == "improving":
+            lines.append(
+                f"  Revenue shows a positive trend (+{fc.slope:,.0f}/yr), and if this"
+                f" continues, the company could reach {_fmt(fc.forecast_values[-1])}"
+                f" by {fc.forecast_years[-1]}."
+            )
+        elif fc.trend_direction == "declining":
+            lines.append(
+                f"  Revenue shows a declining trend ({fc.slope:+,.0f}/yr). If the"
+                f" trend continues, revenue could fall to"
+                f" {_fmt(fc.forecast_values[-1])} by {fc.forecast_years[-1]}."
+            )
+        else:
+            lines.append("  Revenue is broadly flat over the observed period.")
+        lines.append(f"  ({fc.confidence_note})")
+
+
+def _format_sector_section(bm: SectorBenchmark) -> list[str]:
+    """Format the SECTOR COMPARISON section lines."""
+    lines: list[str] = []
+    lines.append(
+        _section(
+            f"SECTOR COMPARISON  ({bm.sector_label} | "
+            f"{bm.n_peers:,} companies | FY {bm.year})"
+        )
+    )
+    peer_range = (
+        f"  Peer revenue range : {_fmt(bm.peer_revenue_low)}"
+        f" - {_fmt(bm.peer_revenue_high)}"
+    )
+    if bm.company_revenue:
+        peer_range += f"  |  This company: {_fmt(bm.company_revenue)}"
+    lines.append(peer_range)
+    if bm.n_peers < 10:
+        lines.append(
+            f"  Only {bm.n_peers} peers found -- benchmarks may not be representative."
+        )
+    lines.append("")
+
+    # Table header
+    col_widths = (26, 12, 12, 8, 8, 8, 12)
+    hdr = (
+        f"  {'Metric':<{col_widths[0]}}"
+        f"{'This Co':>{col_widths[1]}}"
+        f"{'Wt.Avg':>{col_widths[2]}}"
+        f"{'p25':>{col_widths[3]}}"
+        f"{'p50':>{col_widths[4]}}"
+        f"{'p75':>{col_widths[5]}}"
+        f"{'Percentile':>{col_widths[6]}}"
+    )
+    lines.append(hdr)
+    lines.append("  " + "-" * (sum(col_widths) + 2))
+
+    def _row(
+        label: str,
+        co_val: float | None,
+        wt_avg: float | None,
+        quartiles: tuple[float, float, float] | None,
+        pct_rank: float | None,
+    ) -> str:
+        co_s = _fmt(co_val, is_pct=True) if co_val is not None else "n/a"
+        wt_s = _fmt(wt_avg, is_pct=True) if wt_avg is not None else "n/a"
+        if quartiles is not None:
+            p25_s, p50_s, p75_s = (
+                _fmt(quartiles[0], is_pct=True),
+                _fmt(quartiles[1], is_pct=True),
+                _fmt(quartiles[2], is_pct=True),
+            )
+        else:
+            p25_s = p50_s = p75_s = "n/a"
+        pct_s = _ordinal(round(pct_rank)) if pct_rank is not None else "n/a"
+        return (
+            f"  {label:<{col_widths[0]}}"
+            f"{co_s:>{col_widths[1]}}"
+            f"{wt_s:>{col_widths[2]}}"
+            f"{p25_s:>{col_widths[3]}}"
+            f"{p50_s:>{col_widths[4]}}"
+            f"{p75_s:>{col_widths[5]}}"
+            f"{pct_s:>{col_widths[6]}}"
+        )
+
+    lines.append(
+        _row(
+            "Gross Margin",
+            bm.company_gross_margin_pct,
+            bm.wt_gross_margin_pct,
+            bm.gross_margin_quartiles,
+            bm.company_gross_margin_percentile,
+        )
+    )
+    lines.append(
+        _row(
+            "Operating Margin",
+            bm.company_operating_margin_pct,
+            bm.wt_operating_margin_pct,
+            bm.operating_margin_quartiles,
+            bm.company_operating_margin_percentile,
+        )
+    )
+    lines.append(
+        _row(
+            "Net Margin",
+            bm.company_net_margin_pct,
+            bm.wt_net_margin_pct,
+            bm.net_margin_quartiles,
+            bm.company_net_margin_percentile,
+        )
+    )
+
+    lines.append("")
+    lines.append(
+        "  Wt.Avg = revenue-weighted average  |  p25/p50/p75 = unweighted quartiles"
+    )
+    lines.append(
+        "  Percentile = company's rank within the peer distribution"
+        " (higher = better margin)"
+    )
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Top-level API
+# ---------------------------------------------------------------------------
+
+
+def analyse_company(
+    company_id: str,
+    company_name: str | None = None,
+    parquet_path: Path | None = None,
+    forecast_horizon: int = 3,
+    sic_path: Path | None = None,
+) -> CompanyReport:
+    """Load, analyse, and forecast for a single company.
+
+    Parameters
+    ----------
+    company_id:
+        Companies House company number (e.g. ``"01873499"``).
+    company_name:
+        Display name — if omitted, inferred from the data.
+    parquet_path:
+        Override the default parquet location.
+    forecast_horizon:
+        Number of years to project forward.
+    sic_path:
+        Optional path to a SIC code file (parquet or CSV) for sector lookup.
+
+    Returns
+    -------
+    CompanyReport
+        Structured report including history DataFrames and forecast objects.
+        Call ``report.report_text`` for the pre-formatted string output.
+    """
+    path = Path(parquet_path) if parquet_path else _DEFAULT_PARQUET
+    raw = load_company_data(company_id, path)
+    pl_df, bs_df = split_statements(raw)
+    pl_hist = build_pl_history(pl_df)
+    bs_hist = build_bs_history(bs_df)
+    merged = compute_derived_metrics(pl_hist, bs_hist)
+
+    name = company_name
+    if not name and not raw.is_empty():
+        name = raw["entity_current_legal_name"][0]
+    name = name or company_id
+
+    report = CompanyReport(
+        company_name=name,
+        company_id=company_id,
+        num_periods=len(pl_hist),
+        pl_history=merged,
+        bs_history=bs_hist,
+    )
+
+    # ── Sector benchmark ──────────────────────────────────────────────────
+    if not merged.is_empty() and "turnover_gross_operating_revenue" in merged.columns:
+        _latest_pl = merged.row(-1, named=True)
+        _company_rev = _latest_pl.get("turnover_gross_operating_revenue")
+        _company_rev_float = float(_company_rev) if _company_rev else None
+        if (
+            _company_rev_float
+            and not np.isnan(_company_rev_float)
+            and _company_rev_float > 0
+        ):
+            _company_rev_f = _company_rev_float
+            _target_year = merged["period_end"][-1].year
+
+            _sector_name: str | None = None
+            _sector_ids: frozenset[str] | None = None
+            if sic_path is not None:
+                _sector_name, _sector_ids = _load_sic_sector_ids(
+                    Path(sic_path), company_id
+                )
+
+            if _sector_name is not None:
+                _sector_label = f"{_sector_name.replace('_', ' ').title()} sector"
+            else:
+                _sector_label = "size-matched peers"
+
+            _peers = build_peer_group(
+                target_revenue=_company_rev_f,
+                target_year=_target_year,
+                parquet_path=path,
+                sector_company_ids=_sector_ids,
+                exclude_company_id=company_id,
+            )
+            report.sector_benchmark = compute_sector_benchmark(
+                peers=_peers,
+                company_revenue=_company_rev_f,
+                company_gross_margin=_latest_pl.get("gross_margin_pct"),
+                company_op_margin=_latest_pl.get("operating_margin_pct"),
+                company_net_margin=_latest_pl.get("net_margin_pct"),
+                sector_label=_sector_label,
+                target_year=_target_year,
+            )
+
+    # Forecast key metrics
+    forecast_targets = [
+        ("turnover_gross_operating_revenue", "Revenue"),
+        ("gross_profit_loss", "Gross Profit"),
+        ("operating_profit_loss", "Operating Profit"),
+        ("profit_loss_for_period", "Net Profit"),
+        ("gross_margin_pct", "Gross Margin %"),
+        ("operating_margin_pct", "Operating Margin %"),
+    ]
+    years = [r["period_end"].year for r in merged.iter_rows(named=True)]
+    for metric, label in forecast_targets:
+        if metric not in merged.columns:
+            continue
+        values = [
+            float(v) if v is not None else float("nan")
+            for v in merged[metric].to_list()
+        ]
+        fc = forecast_metric(years, values, metric, label, horizon=forecast_horizon)
+        if fc is not None:
+            report.forecasts.append(fc)
+
+    report.report_text = _build_report_text(report)
+    return report
+
+
+def generate_report(
+    company_name_or_id: str,
+    parquet_path: Path | None = None,
+    forecast_horizon: int = 3,
+    sic_path: Path | None = None,
+) -> str:
+    """Search for a company by name (or exact ID) and return a formatted report.
+
+    Parameters
+    ----------
+    company_name_or_id:
+        Partial company name or exact Companies House number.
+    parquet_path:
+        Override the default parquet path.
+    forecast_horizon:
+        Years to project ahead.
+    sic_path:
+        Optional path to a SIC code file for sector comparison.
+
+    Returns
+    -------
+    str
+        Human-readable performance report.
+    """
+    # Try exact ID first (purely numeric / typical CH format)
+    matches = search_companies(company_name_or_id, parquet_path)
+
+    if matches.is_empty():
+        return f"No company found matching '{company_name_or_id}'."
+
+    if len(matches) > 1:
+        listing = "\n".join(
+            f"  {r['company_id']:12s}  {r['entity_current_legal_name']}"
+            for r in matches.iter_rows(named=True)
+        )
+        # Use the first match but warn
+        first_id = matches["company_id"][0]
+        first_name = matches["entity_current_legal_name"][0]
+        msg = (
+            f"Multiple companies matched '{company_name_or_id}':\n{listing}\n\n"
+            f"Using: {first_id} - {first_name}\n"
+            "(Pass the exact company_id to analyse_company() to pick a specific one.)\n"
+        )
+    else:
+        msg = ""
+
+    chosen_id = matches["company_id"][0]
+    chosen_name = matches["entity_current_legal_name"][0]
+    report = analyse_company(
+        chosen_id, chosen_name, parquet_path, forecast_horizon, sic_path=sic_path
+    )
+    return msg + report.report_text
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Exel Computer Systems"
+    print(generate_report(query))

--- a/tests/test_company_analysis.py
+++ b/tests/test_company_analysis.py
@@ -1,0 +1,1023 @@
+"""Tests for the company_analysis module."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import polars as pl
+
+from companies_house_abm.company_analysis import (
+    ForecastResult,
+    SectorBenchmark,
+    _load_sic_sector_ids,
+    _ordinal,
+    analyse_company,
+    build_bs_history,
+    build_peer_group,
+    build_pl_history,
+    compute_derived_metrics,
+    compute_sector_benchmark,
+    forecast_metric,
+    generate_report,
+    split_statements,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_D = pl.Decimal(20, 2)
+
+
+def _make_row(
+    company_id: str = "12345678",
+    entity_name: str = "TEST CO LTD",
+    balance_sheet_date: str = "2023-01-31",
+    period_start: str = "2022-02-01",
+    period_end: str = "2023-01-31",
+    turnover: float | None = 1_000_000.0,
+    gross_profit: float | None = 400_000.0,
+    operating_profit: float | None = 200_000.0,
+    net_profit: float | None = 160_000.0,
+    current_assets: float | None = None,
+    shareholder_funds: float | None = None,
+    employees: float | None = 50.0,
+) -> dict:
+    """Build a minimal raw Companies House row dict."""
+    return {
+        "run_code": "test_run",
+        "company_id": company_id,
+        "date": datetime.date.fromisoformat(balance_sheet_date),
+        "file_type": "test",
+        "taxonomy": "test",
+        "balance_sheet_date": datetime.date.fromisoformat(balance_sheet_date),
+        "companies_house_registered_number": company_id,
+        "entity_current_legal_name": entity_name,
+        "company_dormant": False,
+        "average_number_employees_during_period": (
+            Decimal(str(employees)) if employees else None
+        ),
+        "period_start": datetime.date.fromisoformat(period_start),
+        "period_end": datetime.date.fromisoformat(period_end),
+        "tangible_fixed_assets": None,
+        "debtors": None,
+        "cash_bank_in_hand": None,
+        "current_assets": Decimal(str(current_assets)) if current_assets else None,
+        "creditors_due_within_one_year": None,
+        "creditors_due_after_one_year": None,
+        "net_current_assets_liabilities": None,
+        "total_assets_less_current_liabilities": None,
+        "net_assets_liabilities_including_pension_asset_liability": None,
+        "called_up_share_capital": None,
+        "profit_loss_account_reserve": None,
+        "shareholder_funds": (
+            Decimal(str(shareholder_funds)) if shareholder_funds else None
+        ),
+        "turnover_gross_operating_revenue": (
+            Decimal(str(turnover)) if turnover else None
+        ),
+        "other_operating_income": None,
+        "cost_sales": None,
+        "gross_profit_loss": Decimal(str(gross_profit)) if gross_profit else None,
+        "administrative_expenses": None,
+        "raw_materials_consumables": None,
+        "staff_costs": None,
+        "depreciation_other_amounts_written_off_tangible_intangible_fixed_assets": None,
+        "other_operating_charges_format2": None,
+        "operating_profit_loss": (
+            Decimal(str(operating_profit)) if operating_profit else None
+        ),
+        "profit_loss_on_ordinary_activities_before_tax": None,
+        "tax_on_profit_or_loss_on_ordinary_activities": None,
+        "profit_loss_for_period": Decimal(str(net_profit)) if net_profit else None,
+        "error": None,
+        "zip_url": None,
+    }
+
+
+def _make_instant_row(
+    company_id: str = "12345678",
+    entity_name: str = "TEST CO LTD",
+    date: str = "2023-01-31",
+    current_assets: float | None = 500_000.0,
+    shareholder_funds: float | None = 300_000.0,
+    employees: float | None = 50.0,
+) -> dict:
+    """Build a balance-sheet instant row (period_start == period_end)."""
+    return _make_row(
+        company_id=company_id,
+        entity_name=entity_name,
+        balance_sheet_date=date,
+        period_start=date,
+        period_end=date,
+        turnover=None,
+        gross_profit=None,
+        operating_profit=None,
+        net_profit=None,
+        current_assets=current_assets,
+        shareholder_funds=shareholder_funds,
+        employees=employees,
+    )
+
+
+def _df(rows: list[dict]) -> pl.DataFrame:
+    return pl.from_dicts(rows)
+
+
+# ---------------------------------------------------------------------------
+# split_statements
+# ---------------------------------------------------------------------------
+
+
+class TestSplitStatements:
+    def test_duration_rows_go_to_pl(self):
+        row = _make_row()
+        df = _df([row])
+        pl_df, bs_df = split_statements(df)
+        assert len(pl_df) == 1
+        assert len(bs_df) == 0
+
+    def test_instant_rows_go_to_bs(self):
+        row = _make_instant_row()
+        df = _df([row])
+        pl_df, bs_df = split_statements(df)
+        assert len(pl_df) == 0
+        assert len(bs_df) == 1
+
+    def test_mixed_rows_split_correctly(self):
+        rows = [_make_row(), _make_instant_row()]
+        df = _df(rows)
+        pl_df, bs_df = split_statements(df)
+        assert len(pl_df) == 1
+        assert len(bs_df) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_pl_history / build_bs_history
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHistories:
+    def test_pl_history_sorted_by_period_end(self):
+        rows = [
+            _make_row(period_start="2021-02-01", period_end="2022-01-31"),
+            _make_row(period_start="2022-02-01", period_end="2023-01-31"),
+        ]
+        pl_df, _ = split_statements(_df(rows))
+        hist = build_pl_history(pl_df)
+        dates = hist["period_end"].to_list()
+        assert dates == sorted(dates)
+
+    def test_bs_history_casts_to_float(self):
+        rows = [
+            _make_instant_row(current_assets=500_000.0, shareholder_funds=300_000.0)
+        ]
+        _, bs_df = split_statements(_df(rows))
+        hist = build_bs_history(bs_df)
+        assert hist["current_assets"].dtype == pl.Float64
+
+    def test_empty_returns_empty(self):
+        empty = pl.DataFrame()
+        assert build_pl_history(empty).is_empty()
+        assert build_bs_history(empty).is_empty()
+
+
+# ---------------------------------------------------------------------------
+# compute_derived_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDerivedMetrics:
+    def _two_year_data(self):
+        pl_rows = [
+            _make_row(
+                period_start="2021-02-01",
+                period_end="2022-01-31",
+                turnover=8_000_000.0,
+                gross_profit=3_000_000.0,
+                operating_profit=1_000_000.0,
+                net_profit=800_000.0,
+            ),
+            _make_row(
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=9_000_000.0,
+                gross_profit=3_500_000.0,
+                operating_profit=1_200_000.0,
+                net_profit=960_000.0,
+            ),
+        ]
+        bs_rows = [
+            _make_instant_row(date="2022-01-31", current_assets=4_000_000.0),
+            _make_instant_row(date="2023-01-31", current_assets=4_500_000.0),
+        ]
+        pl_df, _ = split_statements(_df(pl_rows))
+        _, bs_df = split_statements(_df(bs_rows))
+        return build_pl_history(pl_df), build_bs_history(bs_df)
+
+    def test_gross_margin_computed(self):
+        pl_hist, bs_hist = self._two_year_data()
+        merged = compute_derived_metrics(pl_hist, bs_hist)
+        assert "gross_margin_pct" in merged.columns
+        latest = merged.row(-1, named=True)
+        # 3_500_000 / 9_000_000 * 100 ≈ 38.9
+        assert abs(latest["gross_margin_pct"] - 38.89) < 0.1
+
+    def test_operating_margin_computed(self):
+        pl_hist, bs_hist = self._two_year_data()
+        merged = compute_derived_metrics(pl_hist, bs_hist)
+        assert "operating_margin_pct" in merged.columns
+
+    def test_revenue_yoy_growth(self):
+        pl_hist, bs_hist = self._two_year_data()
+        merged = compute_derived_metrics(pl_hist, bs_hist)
+        assert "revenue_yoy_growth_pct" in merged.columns
+        # 9M/8M - 1 = 12.5%
+        latest = merged.row(-1, named=True)
+        assert abs(latest["revenue_yoy_growth_pct"] - 12.5) < 0.1
+
+    def test_empty_pl_returns_empty(self):
+        result = compute_derived_metrics(pl.DataFrame(), pl.DataFrame())
+        assert result.is_empty()
+
+
+# ---------------------------------------------------------------------------
+# forecast_metric
+# ---------------------------------------------------------------------------
+
+
+class TestForecastMetric:
+    def test_returns_none_with_one_data_point(self):
+        result = forecast_metric([2023], [1_000_000.0], "revenue", "Revenue")
+        assert result is None
+
+    def test_returns_forecast_result_with_two_points(self):
+        result = forecast_metric(
+            [2022, 2023], [1_000_000.0, 1_100_000.0], "revenue", "Revenue"
+        )
+        assert isinstance(result, ForecastResult)
+        assert len(result.forecast_years) == 3
+        assert len(result.forecast_values) == 3
+
+    def test_slope_sign(self):
+        # Increasing revenue
+        result = forecast_metric([2020, 2021, 2022], [100.0, 200.0, 300.0], "m", "M")
+        assert result is not None
+        assert result.slope > 0
+        assert result.trend_direction == "improving"
+
+    def test_declining_trend(self):
+        result = forecast_metric([2020, 2021, 2022], [300.0, 200.0, 100.0], "m", "M")
+        assert result is not None
+        assert result.slope < 0
+        assert result.trend_direction == "declining"
+
+    def test_flat_trend(self):
+        result = forecast_metric([2020, 2021, 2022], [500.0, 500.0, 500.0], "m", "M")
+        assert result is not None
+        assert result.trend_direction == "flat"
+
+    def test_nan_values_ignored(self):
+        result = forecast_metric(
+            [2020, 2021, 2022],
+            [100.0, float("nan"), 300.0],
+            "m",
+            "M",
+        )
+        assert result is not None
+        assert len(result.historical_years) == 2  # NaN row excluded
+
+    def test_custom_horizon(self):
+        result = forecast_metric([2021, 2022], [100.0, 200.0], "m", "M", horizon=5)
+        assert result is not None
+        assert len(result.forecast_years) == 5
+        assert result.forecast_years[0] == 2023
+
+    def test_r_squared_perfect_linear(self):
+        result = forecast_metric([2020, 2021, 2022], [100.0, 200.0, 300.0], "m", "M")
+        assert result is not None
+        assert abs(result.r_squared - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# analyse_company (integration, mocked parquet)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_parquet(tmp_path):
+    """Write a minimal parquet with 2 years of data for a test company."""
+    rows = [
+        _make_row(
+            company_id="99999999",
+            entity_name="MOCK COMPANY LTD",
+            period_start="2021-02-01",
+            period_end="2022-01-31",
+            turnover=5_000_000.0,
+            gross_profit=2_000_000.0,
+            operating_profit=600_000.0,
+            net_profit=480_000.0,
+        ),
+        _make_row(
+            company_id="99999999",
+            entity_name="MOCK COMPANY LTD",
+            period_start="2022-02-01",
+            period_end="2023-01-31",
+            turnover=6_000_000.0,
+            gross_profit=2_400_000.0,
+            operating_profit=750_000.0,
+            net_profit=600_000.0,
+        ),
+        _make_instant_row(
+            company_id="99999999",
+            date="2022-01-31",
+            current_assets=2_000_000.0,
+            shareholder_funds=1_000_000.0,
+        ),
+        _make_instant_row(
+            company_id="99999999",
+            date="2023-01-31",
+            current_assets=2_500_000.0,
+            shareholder_funds=1_200_000.0,
+        ),
+    ]
+    path = tmp_path / "test.parquet"
+    pl.from_dicts(rows).write_parquet(path)
+    return path
+
+
+class TestAnalyseCompany:
+    def test_returns_company_report(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert report.company_id == "99999999"
+        assert report.company_name == "MOCK COMPANY LTD"
+
+    def test_pl_history_has_correct_periods(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert report.num_periods == 2
+        assert report.pl_history["period_end"][-1].year == 2023
+
+    def test_forecasts_generated(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert len(report.forecasts) > 0
+        metrics = [f.metric for f in report.forecasts]
+        assert "turnover_gross_operating_revenue" in metrics
+
+    def test_report_text_is_string(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert isinstance(report.report_text, str)
+        assert "MOCK COMPANY LTD" in report.report_text
+
+    def test_missing_company_returns_empty_report(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        report = analyse_company("00000000", parquet_path=path)
+        assert report.num_periods == 0
+        assert report.pl_history.is_empty()
+
+    def test_custom_forecast_horizon(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        report = analyse_company("99999999", parquet_path=path, forecast_horizon=5)
+        revenue_fc = next(
+            f
+            for f in report.forecasts
+            if f.metric == "turnover_gross_operating_revenue"
+        )
+        assert len(revenue_fc.forecast_years) == 5
+
+
+class TestGenerateReport:
+    def test_no_match_returns_message(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        result = generate_report("NONEXISTENT CORP XYZ", parquet_path=path)
+        assert "No company found" in result
+
+    def test_single_match_returns_report(self, tmp_path):
+        path = _make_mock_parquet(tmp_path)
+        result = generate_report("MOCK COMPANY", parquet_path=path)
+        assert "MOCK COMPANY LTD" in result
+        assert "PROFIT & LOSS" in result
+
+    def test_multiple_matches_warns(self, tmp_path):
+        # Write two companies with similar names
+        rows = [
+            _make_row(company_id="11111111", entity_name="ACME LTD"),
+            _make_row(company_id="22222222", entity_name="ACME HOLDINGS LTD"),
+        ]
+        path = tmp_path / "multi.parquet"
+        pl.from_dicts(rows).write_parquet(path)
+        result = generate_report("ACME", parquet_path=path)
+        assert "Multiple companies matched" in result
+
+
+# ---------------------------------------------------------------------------
+# _ordinal
+# ---------------------------------------------------------------------------
+
+
+class TestOrdinal:
+    def test_first(self):
+        assert _ordinal(1) == "1st"
+
+    def test_second(self):
+        assert _ordinal(2) == "2nd"
+
+    def test_third(self):
+        assert _ordinal(3) == "3rd"
+
+    def test_fourth_through_tenth(self):
+        for n in range(4, 11):
+            assert _ordinal(n).endswith("th"), f"expected 'th' suffix for {n}"
+
+    def test_eleventh_twelfth_thirteenth(self):
+        # Teen exceptions: 11th, 12th, 13th — NOT 11st, 12nd, 13rd
+        assert _ordinal(11) == "11th"
+        assert _ordinal(12) == "12th"
+        assert _ordinal(13) == "13th"
+
+    def test_twenty_first(self):
+        assert _ordinal(21) == "21st"
+
+    def test_hundred(self):
+        assert _ordinal(100) == "100th"
+
+    def test_hundred_and_eleventh(self):
+        # 111 ends in 11 → "th"
+        assert _ordinal(111) == "111th"
+
+
+# ---------------------------------------------------------------------------
+# build_peer_group
+# ---------------------------------------------------------------------------
+
+
+def _make_peers_parquet(tmp_path: object, peers: list[dict]) -> object:
+    """Write a parquet containing the target company plus extra peer rows."""
+    from pathlib import Path
+
+    p = Path(str(tmp_path)) / "peers.parquet"  # type: ignore[arg-type]
+    pl.from_dicts(peers).write_parquet(p)
+    return p
+
+
+class TestBuildPeerGroup:
+    def _peer_rows(self) -> list[dict]:
+        """10 peer companies, all with £1m revenue in FY2023."""
+        rows = []
+        for i in range(10):
+            cid = f"PEER{i:04d}"
+            rows.append(
+                _make_row(
+                    company_id=cid,
+                    entity_name=f"PEER CO {i}",
+                    period_start="2022-02-01",
+                    period_end="2023-01-31",
+                    turnover=1_000_000.0,
+                    gross_profit=400_000.0,
+                    operating_profit=200_000.0,
+                    net_profit=160_000.0,
+                )
+            )
+        return rows
+
+    def test_returns_duration_rows_only(self, tmp_path):
+        """Instant (balance-sheet) rows must be excluded."""
+        instant = _make_instant_row(company_id="INST0001", date="2023-01-31")
+        rows = [*self._peer_rows(), instant]
+        path = _make_peers_parquet(tmp_path, rows)
+        peers = build_peer_group(1_000_000.0, 2023, path)
+        assert "INST0001" not in peers["company_id"].to_list()
+
+    def test_filters_by_revenue_band(self, tmp_path):
+        """Companies outside the revenue band must be excluded."""
+        rows = self._peer_rows()
+        # Add a company with revenue way outside the default 4x band
+        rows.append(
+            _make_row(
+                company_id="HUGE0001",
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=100_000_000.0,  # 100x target - outside 4x band
+            )
+        )
+        rows.append(
+            _make_row(
+                company_id="TINY0001",
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=1_000.0,  # 1/1000x target - outside band
+            )
+        )
+        path = _make_peers_parquet(tmp_path, rows)
+        peers = build_peer_group(1_000_000.0, 2023, path)
+        ids = peers["company_id"].to_list()
+        assert "HUGE0001" not in ids
+        assert "TINY0001" not in ids
+        assert len(ids) == 10  # original 10 peers only
+
+    def test_filters_by_year_window(self, tmp_path):
+        """Companies from a year outside the window must be excluded."""
+        rows = self._peer_rows()
+        rows.append(
+            _make_row(
+                company_id="OLD00001",
+                period_start="2018-02-01",
+                period_end="2019-01-31",
+                turnover=1_000_000.0,
+            )
+        )
+        path = _make_peers_parquet(tmp_path, rows)
+        peers = build_peer_group(1_000_000.0, 2023, path, year_window=1)
+        assert "OLD00001" not in peers["company_id"].to_list()
+
+    def test_excludes_target_company(self, tmp_path):
+        rows = self._peer_rows()
+        path = _make_peers_parquet(tmp_path, rows)
+        first_id = rows[0]["company_id"]
+        peers = build_peer_group(1_000_000.0, 2023, path, exclude_company_id=first_id)
+        assert first_id not in peers["company_id"].to_list()
+        assert len(peers) == 9
+
+    def test_one_row_per_company(self, tmp_path):
+        """When a company has multiple periods only the most recent is kept."""
+        rows = self._peer_rows()
+        cid = "MULTI001"
+        # Same company, two overlapping periods
+        rows.append(
+            _make_row(
+                company_id=cid,
+                period_start="2021-02-01",
+                period_end="2022-01-31",
+                turnover=1_000_000.0,
+            )
+        )
+        rows.append(
+            _make_row(
+                company_id=cid,
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=1_200_000.0,
+            )
+        )
+        path = _make_peers_parquet(tmp_path, rows)
+        peers = build_peer_group(1_000_000.0, 2023, path)
+        multi_rows = peers.filter(pl.col("company_id") == cid)
+        assert len(multi_rows) == 1
+        # The kept row should be the most recent (2023)
+        assert multi_rows["period_end"][0].year == 2023
+
+    def test_sector_company_ids_filter(self, tmp_path):
+        """Only companies in sector_company_ids are returned."""
+        rows = self._peer_rows()
+        path = _make_peers_parquet(tmp_path, rows)
+        # Only allow the first 3 companies
+        allowed = frozenset(r["company_id"] for r in rows[:3])
+        peers = build_peer_group(1_000_000.0, 2023, path, sector_company_ids=allowed)
+        assert set(peers["company_id"].to_list()) == allowed
+
+    def test_max_peers_cap(self, tmp_path):
+        rows = self._peer_rows()
+        path = _make_peers_parquet(tmp_path, rows)
+        peers = build_peer_group(1_000_000.0, 2023, path, max_peers=3)
+        assert len(peers) <= 3
+
+    def test_empty_parquet_returns_empty(self, tmp_path):
+        path = tmp_path / "empty.parquet"
+        pl.from_dicts([_make_row()]).head(0).write_parquet(path)
+        peers = build_peer_group(1_000_000.0, 2023, path)
+        assert peers.is_empty()
+
+    def test_custom_revenue_factor(self, tmp_path):
+        """A narrow revenue_factor=1.1 should exclude most peers."""
+        rows = self._peer_rows()
+        # Add a company at 2x target revenue - inside 4x band but outside 1.1x band
+        rows.append(
+            _make_row(
+                company_id="WIDE0001",
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=2_000_000.0,
+            )
+        )
+        path = _make_peers_parquet(tmp_path, rows)
+        peers_wide = build_peer_group(1_000_000.0, 2023, path, revenue_factor=4.0)
+        peers_narrow = build_peer_group(1_000_000.0, 2023, path, revenue_factor=1.1)
+        assert len(peers_wide) > len(peers_narrow)
+        assert "WIDE0001" not in peers_narrow["company_id"].to_list()
+
+
+# ---------------------------------------------------------------------------
+# compute_sector_benchmark
+# ---------------------------------------------------------------------------
+
+
+def _peers_df(
+    revenues: list[float],
+    gross_profits: list[float | None] | None = None,
+    op_profits: list[float | None] | None = None,
+    net_profits: list[float | None] | None = None,
+) -> pl.DataFrame:
+    """Build a minimal peers DataFrame for compute_sector_benchmark tests."""
+    n = len(revenues)
+    gp = gross_profits if gross_profits is not None else [r * 0.4 for r in revenues]
+    op = op_profits if op_profits is not None else [r * 0.2 for r in revenues]
+    np_ = net_profits if net_profits is not None else [r * 0.16 for r in revenues]
+    return pl.DataFrame(
+        {
+            "company_id": [f"P{i:04d}" for i in range(n)],
+            "period_end": [datetime.date(2023, 1, 31)] * n,
+            "turnover_gross_operating_revenue": revenues,
+            "gross_profit_loss": gp,
+            "operating_profit_loss": op,
+            "profit_loss_for_period": np_,
+        }
+    )
+
+
+class TestComputeSectorBenchmark:
+    def test_returns_none_on_empty_peers(self):
+        empty = _peers_df([]).head(0)
+        result = compute_sector_benchmark(
+            empty, 1_000_000.0, 40.0, 20.0, 16.0, "test peers", 2023
+        )
+        assert result is None
+
+    def test_returns_sector_benchmark_instance(self):
+        peers = _peers_df([1_000_000.0] * 10)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "test peers", 2023
+        )
+        assert isinstance(result, SectorBenchmark)
+
+    def test_n_peers_matches_input(self):
+        peers = _peers_df([1_000_000.0] * 7)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.n_peers == 7
+
+    def test_sector_label_and_year(self):
+        peers = _peers_df([1_000_000.0] * 5)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "technology sector", 2023
+        )
+        assert result is not None
+        assert result.sector_label == "technology sector"
+        assert result.year == 2023
+
+    def test_revenue_weighted_average_correct(self):
+        """Larger companies get more weight in the sector average.
+
+        Two companies: company A has revenue 1m and gross margin 10%,
+        company B has revenue 9m and gross margin 50%.
+        Revenue-weighted average = (1*10 + 9*50) / (1+9) = 460/10 = 46%.
+        """
+        peers = _peers_df(
+            revenues=[1_000_000.0, 9_000_000.0],
+            gross_profits=[100_000.0, 4_500_000.0],  # 10% and 50%
+            op_profits=[0.0, 0.0],
+            net_profits=[0.0, 0.0],
+        )
+        result = compute_sector_benchmark(
+            peers, 5_000_000.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.wt_gross_margin_pct is not None
+        assert abs(result.wt_gross_margin_pct - 46.0) < 0.01
+
+    def test_equal_weight_gives_simple_average(self):
+        """Equal-revenue peers → weighted avg equals unweighted avg."""
+        peers = _peers_df(
+            revenues=[1_000_000.0, 1_000_000.0, 1_000_000.0],
+            gross_profits=[100_000.0, 200_000.0, 300_000.0],  # 10%, 20%, 30%
+            op_profits=[50_000.0, 100_000.0, 150_000.0],
+            net_profits=[40_000.0, 80_000.0, 120_000.0],
+        )
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 20.0, 10.0, 8.0, "test", 2023
+        )
+        assert result is not None
+        # Weighted avg of [10, 20, 30] with equal weights = 20
+        assert abs(result.wt_gross_margin_pct - 20.0) < 0.01  # type: ignore[arg-type]
+
+    def test_quartiles_computed(self):
+        """Four peers → quartiles should be defined."""
+        peers = _peers_df(revenues=[1_000_000.0] * 8)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.gross_margin_quartiles is not None
+        p25, p50, p75 = result.gross_margin_quartiles
+        assert p25 <= p50 <= p75
+
+    def test_quartiles_none_for_too_few_peers(self):
+        """Fewer than 4 peers → quartiles are None."""
+        peers = _peers_df(revenues=[1_000_000.0] * 3)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.gross_margin_quartiles is None
+
+    def test_percentile_rank_at_median(self):
+        """A company at the median of its peers should rank near 50th percentile."""
+        # 9 peers at gross margins 10%, 20%, ..., 90%
+        revenues = [1_000_000.0] * 9
+        multipliers = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        gross_profits = [rev * m for rev, m in zip(revenues, multipliers, strict=False)]
+        peers = _peers_df(revenues=revenues, gross_profits=gross_profits)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 50.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        # Company gross margin 50% = median → ~50th percentile
+        assert result.company_gross_margin_percentile is not None
+        assert abs(result.company_gross_margin_percentile - 50.0) < 10.0
+
+    def test_percentile_rank_above_all_peers(self):
+        """Company margin higher than all peers → near 100th percentile."""
+        peers = _peers_df(
+            revenues=[1_000_000.0] * 5,
+            gross_profits=[100_000.0] * 5,  # all at 10%
+        )
+        result = compute_sector_benchmark(
+            peers,
+            1_000_000.0,
+            90.0,
+            20.0,
+            16.0,
+            "test",
+            2023,  # company at 90%
+        )
+        assert result is not None
+        assert result.company_gross_margin_percentile is not None
+        assert result.company_gross_margin_percentile > 90.0
+
+    def test_percentile_none_when_company_margin_none(self):
+        peers = _peers_df(revenues=[1_000_000.0] * 5)
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, None, None, None, "test", 2023
+        )
+        assert result is not None
+        assert result.company_gross_margin_percentile is None
+        assert result.company_operating_margin_percentile is None
+        assert result.company_net_margin_percentile is None
+
+    def test_peer_revenue_range(self):
+        peers = _peers_df(revenues=[500_000.0, 1_000_000.0, 2_000_000.0])
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.peer_revenue_low == 500_000.0
+        assert result.peer_revenue_high == 2_000_000.0
+
+    def test_company_revenue_stored(self):
+        peers = _peers_df(revenues=[1_000_000.0] * 4)
+        result = compute_sector_benchmark(
+            peers, 1_234_567.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.company_revenue == 1_234_567.0
+
+    def test_all_null_profits_returns_none_weighted_avgs(self):
+        """If all gross_profit_loss is null the weighted avg must be None."""
+        peers = _peers_df(
+            revenues=[1_000_000.0] * 5,
+            gross_profits=[None] * 5,
+        )
+        result = compute_sector_benchmark(
+            peers, 1_000_000.0, 40.0, 20.0, 16.0, "test", 2023
+        )
+        assert result is not None
+        assert result.wt_gross_margin_pct is None
+
+
+# ---------------------------------------------------------------------------
+# _load_sic_sector_ids
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSicSectorIds:
+    def _sic_csv(self, tmp_path, rows: list[tuple[str, str]]) -> object:
+        """Write a minimal SIC CSV and return the path."""
+        from pathlib import Path
+
+        p = Path(str(tmp_path)) / "sic.csv"
+        lines = ["companies_house_registered_number,sic_code"]
+        for cid, sic in rows:
+            lines.append(f"{cid},{sic}")
+        p.write_text("\n".join(lines))
+        return p
+
+    def test_returns_sector_and_ids_from_csv(self, tmp_path):
+        path = self._sic_csv(
+            tmp_path,
+            [
+                ("01873499", "62012"),  # SIC 62 → "technology"
+                ("00000001", "62020"),
+                ("00000002", "47710"),  # different sector
+            ],
+        )
+        sector, ids = _load_sic_sector_ids(path, "01873499")
+        assert sector is not None
+        assert ids is not None
+        # Both 62xxx companies should be in the sector set
+        assert "01873499" in ids
+        assert "00000001" in ids
+        assert "00000002" not in ids
+
+    def test_returns_none_for_unknown_company(self, tmp_path):
+        path = self._sic_csv(tmp_path, [("99999999", "62012")])
+        sector, ids = _load_sic_sector_ids(path, "12345678")
+        assert sector is None
+        assert ids is None
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        from pathlib import Path
+
+        sector, ids = _load_sic_sector_ids(Path(tmp_path) / "nope.csv", "01873499")
+        assert sector is None
+        assert ids is None
+
+    def test_returns_none_for_wrong_columns(self, tmp_path):
+        from pathlib import Path
+
+        p = Path(str(tmp_path)) / "bad.csv"
+        p.write_text("foo,bar\n1,2\n")
+        sector, ids = _load_sic_sector_ids(p, "01873499")
+        assert sector is None
+        assert ids is None
+
+    def test_parquet_format(self, tmp_path):
+        from pathlib import Path
+
+        p = Path(str(tmp_path)) / "sic.parquet"
+        pl.DataFrame(
+            {
+                "companies_house_registered_number": ["01873499", "00000001"],
+                "sic_code": ["62012", "62020"],
+            }
+        ).write_parquet(p)
+        sector, ids = _load_sic_sector_ids(p, "01873499")
+        assert sector is not None
+        assert ids is not None
+
+    def test_company_id_zero_padded(self, tmp_path):
+        """Short company IDs in the SIC file should still match."""
+        path = self._sic_csv(
+            tmp_path,
+            [("1873499", "62012")],  # 7 digits, needs zfill(8)
+        )
+        sector, _ids = _load_sic_sector_ids(path, "01873499")
+        assert sector is not None
+
+
+# ---------------------------------------------------------------------------
+# Sector benchmark in analyse_company / generate_report
+# ---------------------------------------------------------------------------
+
+
+def _make_parquet_with_peers(tmp_path) -> object:
+    """Write a parquet with one target company + 20 peer companies."""
+    from pathlib import Path
+
+    target = [
+        _make_row(
+            company_id="99999999",
+            entity_name="TARGET CO LTD",
+            period_start="2022-02-01",
+            period_end="2023-01-31",
+            turnover=5_000_000.0,
+            gross_profit=2_000_000.0,
+            operating_profit=600_000.0,
+            net_profit=480_000.0,
+        )
+    ]
+    peers = [
+        _make_row(
+            company_id=f"PEER{i:04d}",
+            entity_name=f"PEER CO {i}",
+            period_start="2022-02-01",
+            period_end="2023-01-31",
+            turnover=5_000_000.0,
+            gross_profit=1_500_000.0,
+            operating_profit=400_000.0,
+            net_profit=300_000.0,
+        )
+        for i in range(20)
+    ]
+    p = Path(str(tmp_path)) / "with_peers.parquet"
+    pl.from_dicts(target + peers).write_parquet(p)
+    return p
+
+
+class TestSectorBenchmarkIntegration:
+    def test_benchmark_populated_when_peers_exist(self, tmp_path):
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert report.sector_benchmark is not None
+
+    def test_benchmark_none_when_no_peers(self, tmp_path):
+        """Parquet with only the target company → no peers → benchmark is None."""
+        rows = [
+            _make_row(
+                company_id="99999999",
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=5_000_000.0,
+            )
+        ]
+        path = tmp_path / "solo.parquet"
+        pl.from_dicts(rows).write_parquet(path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert report.sector_benchmark is None
+
+    def test_target_company_excluded_from_peers(self, tmp_path):
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert report.sector_benchmark is not None
+        # n_peers should equal the 20 peers, not 21 (target excluded)
+        assert report.sector_benchmark.n_peers == 20
+
+    def test_sector_label_is_size_matched_without_sic(self, tmp_path):
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert report.sector_benchmark is not None
+        assert "size-matched" in report.sector_benchmark.sector_label
+
+    def test_report_text_contains_sector_section(self, tmp_path):
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert "SECTOR COMPARISON" in report.report_text
+
+    def test_report_text_contains_weighted_avg_label(self, tmp_path):
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert "Wt.Avg" in report.report_text
+
+    def test_report_text_shows_peer_count(self, tmp_path):
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        assert "20" in report.report_text  # 20 peers
+
+    def test_company_higher_margin_ranks_above_50th(self, tmp_path):
+        """Target has 40% gross margin; peers at 30% → should rank above 50th."""
+        path = _make_parquet_with_peers(tmp_path)
+        report = analyse_company("99999999", parquet_path=path)
+        bm = report.sector_benchmark
+        assert bm is not None
+        if bm.company_gross_margin_percentile is not None:
+            assert bm.company_gross_margin_percentile > 50.0
+
+    def test_sic_path_narrows_to_sector(self, tmp_path):
+        """With a SIC file, the sector label should reflect the sector name."""
+        path = _make_parquet_with_peers(tmp_path)
+
+        # SIC file: target is SIC 62xxx (technology), peers are mixed
+        sic_rows = [("99999999", "62012")]
+        for i in range(20):
+            sic_code = "62020" if i < 10 else "47710"  # half tech, half retail
+            sic_rows.append((f"PEER{i:04d}", sic_code))
+
+        from pathlib import Path
+
+        sic_path = Path(str(tmp_path)) / "sic.csv"
+        lines = ["companies_house_registered_number,sic_code"]
+        for cid, sic in sic_rows:
+            lines.append(f"{cid},{sic}")
+        sic_path.write_text("\n".join(lines))
+
+        report = analyse_company("99999999", parquet_path=path, sic_path=sic_path)
+        bm = report.sector_benchmark
+        assert bm is not None
+        # Sector label should mention technology, not "size-matched peers"
+        assert "size-matched" not in bm.sector_label
+        # Only the 10 technology peers (PEER0000-PEER0009 with SIC 62xxx)
+        assert bm.n_peers == 10
+
+    def test_generate_report_passes_sic_path(self, tmp_path):
+        """generate_report sic_path kwarg reaches analyse_company."""
+        path = _make_parquet_with_peers(tmp_path)
+        result = generate_report("TARGET", parquet_path=path)
+        assert "SECTOR COMPARISON" in result
+
+    def test_benchmark_none_when_no_revenue(self, tmp_path):
+        """Company with null revenue → no benchmark computed."""
+        rows = [
+            _make_row(
+                company_id="NOREV001",
+                period_start="2022-02-01",
+                period_end="2023-01-31",
+                turnover=None,  # no revenue
+            )
+        ]
+        path = tmp_path / "norev.parquet"
+        pl.from_dicts(rows).write_parquet(path)
+        report = analyse_company("NOREV001", parquet_path=path)
+        assert report.sector_benchmark is None


### PR DESCRIPTION
## Summary

- **`company_analysis.py`**: New module with `CompanyReport`, `SectorBenchmark`, `analyse_company`, and `generate_report`
- **Sector benchmarking**: `build_peer_group` uses lazy Polars scan with predicate pushdown to find size-matched peers (revenue band ±4x, ±1 year window, optional SIC sector filter); `compute_sector_benchmark` computes revenue-weighted average margins, unweighted quartiles (p25/p50/p75), and company percentile rank via `scipy.stats.percentileofscore`
- **Report formatting**: `_format_sector_section` renders a markdown table showing This Co / Wt.Avg / p25 / p50 / p75 / Percentile for gross, operating, and net margins
- **SIC sector lookup**: `_load_sic_sector_ids` reads a CSV/Parquet SIC file to narrow peer group to companies in the same sector
- **`analyse_company` CLI integration**: `--sic-path` kwarg passed through to `generate_report`; benchmark section appended when peers are found

## Test plan

- [x] `TestOrdinal` — 1st/2nd/3rd/11th-13th/21st/111th suffix edge cases
- [x] `TestBuildPeerGroup` — revenue band, year window, exclusion, one-row-per-company, sector filter, max_peers cap, empty parquet, custom factor
- [x] `TestComputeSectorBenchmark` — None on empty; revenue-weighted avg; equal-weight; quartiles; percentile at median/above all; None for missing margin; all-null profits
- [x] `TestLoadSicSectorIds` — CSV, parquet, unknown company, missing file, wrong columns, zero-padded ID
- [x] `TestSectorBenchmarkIntegration` — benchmark populated end-to-end; target excluded; size-matched label without SIC; report text contains "SECTOR COMPARISON" and "Wt.Avg"; SIC narrows sector; `generate_report` passes `sic_path`; None when no revenue

> **Stacked on**: #22 (`feat/ingest-archive-and-check-company`). The diff here shows only the analysis module changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)