### PR TITLE
feat: add UK housing market simulation with bilateral matching

### DIFF
--- a/config/model_parameters.yml
+++ b/config/model_parameters.yml
@@ -60,6 +60,28 @@ agents:
   government:
     exists: true  # Whether to include government agent
 
+  properties:
+    count: 12000  # Number of housing units (> households for vacancy)
+    regions:
+      - "london"
+      - "south_east"
+      - "east"
+      - "south_west"
+      - "west_midlands"
+      - "east_midlands"
+      - "north_west"
+      - "north_east"
+      - "yorkshire"
+      - "scotland"
+      - "wales"
+    types:
+      - "detached"
+      - "semi_detached"
+      - "terraced"
+      - "flat"
+    type_shares: [0.16, 0.24, 0.28, 0.32]
+    average_price: 285000  # UK average house price (GBP, 2024)
+
 # Behavioral parameters
 behavior:
   firms:
@@ -80,6 +102,16 @@ behavior:
     risk_premium_sensitivity: 0.05  # How risk affects interest rates
     lending_threshold: 0.3  # Minimum debt service coverage ratio
     capital_buffer: 0.02  # Buffer above regulatory minimum
+    mortgage:
+      max_ltv: 0.90  # FPC LTV limit
+      max_dti: 4.5  # FPC flow limit (max debt-to-income multiple)
+      stress_test_buffer: 0.03  # BoE stress test: affordability at rate + 3%
+      default_term_months: 300  # 25 years
+      fixed_rate_share: 0.75  # 75% of new mortgages are fixed rate
+      fixed_rate_period: 24  # 2-year fixed period
+      mortgage_risk_weight: 0.35  # Basel standardised for UK residential
+      foreclosure_threshold: 3  # Months in arrears before foreclosure
+      mortgage_spread: 0.015  # Spread over Bank Rate for mortgage pricing
 
 # Market mechanisms
 markets:
@@ -99,6 +131,17 @@ markets:
     rationing: true  # Whether credit rationing can occur
     collateral_requirement: 0.5  # Required collateral as fraction of loan
     default_rate_base: 0.01  # Base default probability
+
+  housing:
+    search_intensity: 10  # Properties visited per buyer per period
+    initial_markup: 0.05  # Seller asks 5% above recent comparables
+    price_reduction_rate: 0.10  # 10% price reduction per unsold period
+    max_months_listed: 6  # Delist after 6 months
+    backward_expectation_weight: 0.65  # Weight on extrapolative expectations
+    expectation_lookback: 12  # Periods of price history for expectations
+    transaction_cost: 0.05  # Stamp duty + fees as fraction of price
+    maintenance_cost: 0.01  # Annual maintenance as fraction of value
+    rental_yield: 0.045  # Average gross rental yield
 
   interbank:
     active: true  # Whether interbank market operates
@@ -204,6 +247,15 @@ validation:
   wage_share: 0.55  # Labor share of income
   investment_gdp_ratio: 0.17  # Investment as fraction of GDP
   government_debt_gdp: 0.85  # Government debt to GDP ratio
+  # Housing validation targets
+  homeownership_rate: 0.64  # English Housing Survey
+  average_house_price: 285000  # ONS UK HPI 2024
+  price_to_income_ratio: 8.3  # ONS Affordability
+  house_price_growth_mean: 0.035  # Annual, ONS HPI long-run
+  house_price_growth_std: 0.06  # ONS HPI
+  mortgage_ltv_mean: 0.70  # BoE MLAR
+  mortgage_arrears_rate: 0.01  # BoE FSR
+  rental_yield: 0.045  # ONS Rental Index
 
 # Technical settings
 technical:

--- a/docs/housing-market.md
+++ b/docs/housing-market.md
@@ -1,0 +1,308 @@
+# UK Housing Market ABM
+
+## Overview
+
+The housing market module simulates the UK residential property market using
+**bilateral matching with aspiration-level pricing**, following the approach
+described by Farmer (2025) and adapted for the UK by Baptista et al. (2016)
+and Carro et al. (2022).
+
+Unlike the goods or labour markets, the housing market does **not** clear to
+equilibrium. Buyers and sellers are matched bilaterally, prices adjust
+sluggishly through aspiration-level adaptation, and persistent imbalances
+between supply and demand are the norm — just like real housing markets.
+
+## Architecture
+
+### Components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| **Property** | `abm/assets/property.py` | Passive asset: value, type, region, listing state |
+| **Mortgage** | `abm/assets/mortgage.py` | Loan contract: principal, rate, LTV, arrears tracking |
+| **HousingMarket** | `abm/markets/housing.py` | Bilateral matching, aspiration-level pricing |
+| **Household** (extended) | `abm/agents/household.py` | Tenure, buy/rent decision, housing payment |
+| **Bank** (extended) | `abm/agents/bank.py` | Mortgage evaluation, origination, foreclosure |
+| **Config** | `abm/config.py` | `PropertyConfig`, `HousingMarketConfig`, `MortgageConfig` |
+| **Data sources** | `data_sources/land_registry.py`, `data_sources/ons_housing.py` | UK house price and tenure data |
+
+### Data Flow
+
+```
+Household.decide_buy_or_rent()  →  wants_to_buy = True/False
+Owner sell decision (2%/period)  →  Property.list_for_sale()
+                                         ↓
+                            HousingMarket.clear()
+                                         ↓
+                    ┌────────────────────────────────────────┐
+                    │  1. Update asking prices (aspiration)  │
+                    │  2. Collect buyers (wants_to_buy)      │
+                    │  3. Collect listings (on_market)       │
+                    │  4. Bilateral matching                 │
+                    │  5. Update statistics                  │
+                    └────────────────────────────────────────┘
+                                         ↓
+              Bank.evaluate_mortgage() → Bank.originate_mortgage()
+                                         ↓
+                              Property.sell() → ownership transfer
+```
+
+## Key Mechanisms
+
+### Aspiration-Level Pricing (Farmer 2025)
+
+Sellers set asking prices above market value and gradually reduce them:
+
+1. **Initial listing**: `asking_price = market_value × (1 + initial_markup)`
+   (default markup: 5%)
+2. **Monthly reduction**: `asking_price *= (1 - price_reduction_rate)`
+   (default reduction: 10%)
+3. **Delisting**: After `max_months_listed` periods without a sale, the
+   property is removed from the market (default: 6 months)
+
+This creates the characteristic downward price adjustment observed in real
+markets and allows persistent supply-demand imbalances.
+
+### Buy/Rent Decision
+
+Households compare the expected monthly cost of owning versus renting:
+
+- **Cost of owning** = mortgage payment + maintenance − expected appreciation
+- **Cost of renting** = average price × rental yield / 12
+
+Price expectations combine backward-looking trend extrapolation (65% weight)
+with a forward-looking fundamental growth assumption (2% annual, 35% weight),
+following the behavioural expectation formation described by Farmer (2025).
+
+A renter decides to buy if:
+
+1. Owning is cheaper than renting (expected)
+2. They can afford the deposit (≥ 10% of average price)
+
+### FPC Macroprudential Toolkit
+
+Bank mortgage evaluation applies the Financial Policy Committee's
+macroprudential tools:
+
+| Check | Default | Description |
+|-------|---------|-------------|
+| **LTV cap** | 90% | Loan-to-value ratio must not exceed this |
+| **DTI cap** | 4.5× | Debt-to-income ratio must not exceed this |
+| **Stress test** | +3% buffer | Borrower must afford payments at rate + buffer |
+| **Affordability** | <40% income | Stressed monthly payment < 40% of gross income |
+
+These parameters are fully configurable, enabling policy experiments
+(e.g. varying the LTV cap to study bubble sensitivity per Baptista et al.).
+
+### Bilateral Matching
+
+Each period, the market matches buyers to properties:
+
+1. Shuffle buyers randomly (fairness)
+2. Each buyer computes their budget: `wealth + max_mortgage` (where
+   `max_mortgage = annual_income × 4.5`)
+3. Buyer visits up to `search_intensity` (default: 10) affordable properties
+4. Buyer selects the best value: lowest `asking_price / quality` ratio
+5. Bank evaluates the mortgage application
+6. If approved: ownership transfers, mortgage created, seller receives proceeds
+
+## Running a Simulation
+
+### Basic Usage
+
+```python
+from companies_house_abm.abm.model import Simulation
+
+sim = Simulation.from_config()
+result = sim.run(periods=60)  # 60 months = 5 years
+
+# Access housing time series
+for record in result.records:
+    print(
+        f"Period {record.period}: "
+        f"Price=£{record.average_house_price:,.0f} "
+        f"Txns={record.housing_transactions} "
+        f"Ownership={record.homeownership_rate:.1%}"
+    )
+```
+
+### Custom Configuration
+
+```python
+from companies_house_abm.abm.config import (
+    HousingMarketConfig,
+    ModelConfig,
+    MortgageConfig,
+    PropertyConfig,
+    SimulationConfig,
+)
+from companies_house_abm.abm.model import Simulation
+
+config = ModelConfig(
+    simulation=SimulationConfig(periods=120, seed=42),
+    properties=PropertyConfig(count=5000, average_price=300_000),
+    housing_market=HousingMarketConfig(
+        search_intensity=15,
+        price_reduction_rate=0.08,
+    ),
+    mortgage=MortgageConfig(
+        max_ltv=0.80,        # Tighter LTV cap
+        max_dti=4.0,         # Tighter DTI limit
+        stress_test_buffer=0.04,
+    ),
+)
+
+sim = Simulation(config)
+sim.initialize_agents()
+result = sim.run()
+```
+
+### Policy Experiments
+
+Compare the effect of different LTV caps:
+
+```python
+from companies_house_abm.abm.config import ModelConfig, MortgageConfig
+from companies_house_abm.abm.model import Simulation
+
+for max_ltv in [0.75, 0.85, 0.95]:
+    config = ModelConfig(mortgage=MortgageConfig(max_ltv=max_ltv))
+    sim = Simulation(config)
+    sim.initialize_agents()
+    result = sim.run(periods=60)
+    final = result.records[-1]
+    print(
+        f"LTV={max_ltv:.0%}: "
+        f"Price=£{final.average_house_price:,.0f} "
+        f"Ownership={final.homeownership_rate:.1%} "
+        f"Txns={sum(r.housing_transactions for r in result.records)}"
+    )
+```
+
+### Web Application
+
+The economy simulator webapp includes housing parameters:
+
+```bash
+uv run companies-house-abm serve
+# Open http://localhost:8000
+```
+
+Housing-specific parameters in the UI:
+
+- **Max LTV** — Maximum loan-to-value ratio (0.50–1.00)
+- **Max DTI** — Maximum debt-to-income multiple (2.0–7.0)
+- **Search intensity** — Properties visited per buyer per period (1–50)
+
+### Calibration from Live Data
+
+```python
+from companies_house_abm.data_sources import (
+    calibrate_housing,
+    fetch_regional_prices,
+    fetch_tenure_distribution,
+    fetch_affordability_ratio,
+)
+
+# Fetch current UK housing data
+prices = fetch_regional_prices()  # HM Land Registry
+tenure = fetch_tenure_distribution()  # English Housing Survey
+affordability = fetch_affordability_ratio()  # ONS
+
+# Auto-calibrate housing parameters
+prop_config, market_config = calibrate_housing()
+```
+
+## Configuration Reference
+
+### PropertyConfig
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `count` | 12,000 | Number of properties in the simulation |
+| `regions` | 11 UK regions | Region labels for heterogeneity |
+| `types` | 4 types | detached, semi_detached, terraced, flat |
+| `type_shares` | (0.16, 0.24, 0.28, 0.32) | Share of each type |
+| `average_price` | £285,000 | UK average house price |
+
+### HousingMarketConfig
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `search_intensity` | 10 | Properties visited per buyer per period |
+| `initial_markup` | 5% | Initial asking price markup above market value |
+| `price_reduction_rate` | 10% | Monthly price reduction for unsold listings |
+| `max_months_listed` | 6 | Months before delisting |
+| `backward_expectation_weight` | 0.65 | Weight on backward-looking price trend |
+| `expectation_lookback` | 12 | Months of price history for expectations |
+| `transaction_cost` | 5% | Transaction costs (stamp duty etc.) |
+| `maintenance_cost` | 1% | Annual maintenance cost as share of value |
+| `rental_yield` | 4.5% | Gross rental yield |
+
+### MortgageConfig
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_ltv` | 90% | Maximum loan-to-value ratio |
+| `max_dti` | 4.5× | Maximum debt-to-income multiple |
+| `stress_test_buffer` | 3% | Rate buffer for affordability stress test |
+| `default_term_months` | 300 | Default mortgage term (25 years) |
+| `fixed_rate_share` | 75% | Share of new mortgages at fixed rates |
+| `mortgage_risk_weight` | 0.35 | Basel risk weight for mortgage assets |
+| `foreclosure_threshold` | 3 months | Arrears before foreclosure |
+| `mortgage_spread` | 1.5% | Spread over policy rate |
+
+## Simulation Output
+
+Each period record includes:
+
+| Field | Description |
+|-------|-------------|
+| `average_house_price` | Mean transaction price this period |
+| `housing_transactions` | Number of sales completed |
+| `housing_listings` | Properties currently on the market |
+| `homeownership_rate` | Share of households who are owner-occupiers |
+| `house_price_inflation` | Monthly house price change |
+| `total_mortgage_lending` | Total new mortgage lending this period |
+| `foreclosures` | Mortgages foreclosed this period |
+
+Time-series properties on `SimulationResult`:
+
+- `result.house_price_series` — average house price per period
+- `result.homeownership_series` — homeownership rate per period
+
+## Validation Targets
+
+| Metric | Target | Source |
+|--------|--------|--------|
+| Homeownership rate | ~64% | English Housing Survey 2023-24 |
+| Average house price | ~£285,000 | ONS UK HPI |
+| Price-to-income ratio | ~8.3 | ONS Affordability Ratio |
+| Average mortgage LTV | ~70% | BoE MLAR |
+| Average time to sell | 3–4 months | Rightmove/Zoopla |
+| Gross rental yield | 4–5% | ONS Rental Index |
+
+## Theoretical Background
+
+The housing market module is based on three key papers:
+
+1. **Farmer (2025)** "Quantitative agent-based models: a promising
+   alternative for macroeconomics" — describes the aspiration-level pricing
+   mechanism, backward-looking expectations, and the insight that lending
+   policy (not interest rates) was the primary driver of the 2008 bubble.
+
+2. **Baptista et al. (2016)** "Macroprudential policy in an agent-based
+   model of the UK housing market" — adapts the Farmer/Geanakoplos
+   Washington DC model for the UK, adding FPC macroprudential tools.
+
+3. **Carro et al. (2022)** — further development of the Bank of England
+   housing ABM with improved calibration and validation.
+
+## Future Development
+
+- **bytes-and-mortar integration**: Use HM Land Registry Price Paid and
+  EPC data for property-level calibration
+- **Mortgage default risk**: Combine housing simulation, economy simulation,
+  and borrower characteristics to estimate P(default)
+- **Regional heterogeneity**: Full spatial model with 11 UK regions
+- **Rental market**: Explicit rental market mechanism with landlord agents

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,8 +111,17 @@ from companies_house_abm.abm import Simulation, load_config
 
 config = load_config("config/model_parameters.yml")
 sim = Simulation(config)
-sim.run()
+sim.initialize_agents()
+result = sim.run(periods=60)
+
+# Access housing market results
+for rec in result.records:
+    print(f"Period {rec.period}: Price=£{rec.average_house_price:,.0f} "
+          f"Ownership={rec.homeownership_rate:.1%}")
 ```
+
+See the [Housing Market](housing-market.md) documentation for full details on
+running housing simulations, policy experiments, and calibration from live data.
 
 ## Development
 

--- a/docs/modelling-approach.md
+++ b/docs/modelling-approach.md
@@ -27,22 +27,28 @@ Key attributes: `sector`, `employees`, `turnover`, `capital`, `cash`, `debt`, `e
 
 ### Household
 
-Households supply labour and consume goods.  Each period:
+Households supply labour, consume goods, and participate in the housing market.  Each period:
 
 1. **Receive income** — wages if employed, transfer income if not.
-2. **Consume** — a consumption function combining a fraction of income (MPC) and a small draw on wealth.
-3. **Save** — unspent income accumulates as deposits/wealth.
+2. **Make housing payment** — mortgage amortisation (if owner) or rent payment (if renter).
+3. **Consume** — a consumption function combining a fraction of remaining income (MPC) and a small draw on wealth.
+4. **Save** — unspent income accumulates as deposits/wealth.
+5. **Decide buy or rent** — compare expected cost of owning vs renting using backward/forward-looking price expectations (Farmer 2025).
 
-Key attributes: `income`, `wealth`, `mpc`, `employed`, `wage`.
+Key attributes: `income`, `wealth`, `mpc`, `employed`, `wage`, `tenure`, `property_id`, `mortgage`, `rent`, `housing_wealth`, `wants_to_buy`.
 
 ### Bank
 
-Banks accept deposits, extend credit and must satisfy regulatory constraints.  Each period:
+Banks accept deposits, extend credit, originate mortgages, and must satisfy regulatory constraints.  Each period:
 
 1. **Set lending rate** — policy rate plus a markup, with a risk premium that rises with non-performing loans (NPLs).
-2. **Evaluate loans** — check collateral coverage and debt-service coverage ratios.
-3. **Record income/expense** — interest income on loans, interest expense on deposits, provisions for NPLs.
-4. **Update capital** — profit added to equity.
+2. **Set mortgage rate** — policy rate plus a spread and risk premium.
+3. **Evaluate loans** — check collateral coverage and debt-service coverage ratios.
+4. **Evaluate mortgages** — apply FPC macroprudential checks (LTV, DTI, affordability stress test).
+5. **Originate mortgages** — create mortgage contracts for approved applications.
+6. **Assess foreclosures** — foreclose on mortgages with 3+ months of arrears.
+7. **Record income/expense** — interest income on loans, interest expense on deposits, provisions for NPLs.
+8. **Update capital** — profit added to equity.  Mortgage book included in risk-weighted assets at 0.35 weight.
 
 Regulatory constraints follow Basel III: a minimum capital-adequacy ratio and a capital buffer above that minimum.
 
@@ -79,23 +85,39 @@ Matching occurs with frictions:
 
 Firms with negative cash balances apply for loans.  Applications are distributed across banks in round-robin fashion.  Each bank evaluates the application against collateral and debt-service-coverage thresholds.  When credit rationing is enabled, applications that fail the evaluation are rejected outright.
 
+### Housing Market
+
+The housing market uses **bilateral matching with aspiration-level pricing** (Farmer 2025), fundamentally different from the equilibrium-clearing approach used for goods and labour.  Each period:
+
+1. **Sellers update asking prices** — unsold listings are reduced by 10% per period; after 6 months they are delisted (aspiration-level adaptation).
+2. **Buyers search** — each buyer visits up to 10 listed properties within their budget and selects the best value.
+3. **Mortgage evaluation** — banks apply FPC macroprudential checks: LTV cap (90%), DTI limit (4.5x), and an affordability stress test (+3% rate buffer).
+4. **Transactions** — if the mortgage is approved, ownership transfers, the bank creates a mortgage, and aggregate statistics are updated.
+
+Properties are passive assets (not agents) with region, type, quality, and price attributes.  Mortgages are shared reference objects between banks and households.
+
+See [Housing Market](housing-market.md) for full documentation.
+
 ## Within-Period Sequence
 
-Each simulation period follows this sequence:
+Each simulation period follows this 16-step sequence:
 
 1. Government resets period flows.
 2. Central bank sets the policy rate (Taylor rule).
-3. Banks update lending rates from the new policy rate.
+3. Banks update lending rates **and mortgage rates** from the new policy rate.
 4. Credit market clears (firms borrow, defaults processed).
 5. Firms step (plan, price, labour demand, produce, financials).
 6. Labour market clears (separations, matching).
-7. Households step (income, consumption, saving).
-8. Government calculates spending.
-9. Goods market clears (demand allocated, markup adaptation).
-10. Taxes collected (corporate and income).
-11. Government ends period (deficit, debt).
-12. Central bank observes inflation and output gap.
-13. Banks step (income calculation, capital update).
+7. **Banks assess foreclosures** (mortgages in arrears).
+8. Households step (income, **housing payment**, consumption, saving).
+9. **Households make buy/sell decisions** (buy-vs-rent comparison, owner sell probability).
+10. **Housing market clears** (bilateral matching, mortgage origination).
+11. Government calculates spending.
+12. Goods market clears (demand allocated, markup adaptation).
+13. Taxes collected (corporate and income).
+14. Government ends period (deficit, debt).
+15. Central bank observes inflation and output gap.
+16. Banks step (income calculation, capital update).
 
 ## Configuration
 
@@ -105,9 +127,12 @@ All parameters are stored in `config/model_parameters.yml` and loaded into froze
 |---------|----------|
 | `simulation` | `periods`, `seed`, `warm_up_periods` |
 | `agents.firms` | `sample_size`, `sectors`, `entry_rate` |
-| `Behaviour.firms` | `price_markup`, `inventory_target_ratio` |
+| `behavior.firms` | `price_markup`, `inventory_target_ratio` |
 | `agents.households` | `count`, `mpc_mean`, `income_mean` |
 | `agents.banks` | `count`, `capital_requirement` |
+| `agents.properties` | `count`, `regions`, `types`, `average_price` |
+| `behavior.banks.mortgage` | `max_ltv`, `max_dti`, `stress_test_buffer` |
+| `markets.housing` | `search_intensity`, `price_reduction_rate`, `rental_yield` |
 | `policy.central_bank` | Taylor rule coefficients |
 | `policy.government` | Tax rates, spending ratio, transfers |
 | `markets.*` | Price adjustment speed, matching efficiency |
@@ -124,6 +149,10 @@ The model aims to reproduce the following UK stylised facts:
 | Inflation | Mean $\approx 2\%$ |
 | Wage share of income | $\approx 55\%$ |
 | Investment / GDP | $\approx 17\%$ |
+| Homeownership rate | $\approx 64\%$ |
+| Average house price | $\approx$ £285,000 |
+| Price-to-income ratio | $\approx 8.3$ |
+| Gross rental yield | $4{-}5\%$ |
 
 ## Interactive Exploration
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Home: index.md
   - ABM Design: abm-design.md
   - Modelling Approach: modelling-approach.md
+  - Housing Market: housing-market.md
   - Firm Data Analysis: firm-data-analysis.md
   - Stochastic Behaviour & Bounded Rationality: stochastic-bounded-rationality.md
   - API Reference: api.md

--- a/notebooks/housing_market.py
+++ b/notebooks/housing_market.py
@@ -1,0 +1,563 @@
+import marimo
+
+__generated_with = "0.10.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    mo.md(
+        """
+        # Housing Market Explorer
+
+        This notebook explores the **HousingMarket** mechanism: a bilateral-matching
+        market with aspiration-level pricing following Farmer (2025) and Baptista et al.
+        (2016).
+
+        Unlike goods or labour markets, the housing market does **not** clear to
+        equilibrium.  Prices adjust sluggishly through aspiration-level adaptation,
+        buyers search a limited number of listings, and supply-demand imbalances persist.
+
+        The key actors are:
+        - **Properties** - housing units with asking prices that fall each period they
+          remain unsold.
+        - **Households** - buyers (renters who want to purchase) and sellers (owners who
+          want to move).
+        - **Banks** - lenders that approve or reject mortgages based on LTV and DTI
+          constraints.
+        """
+    )
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    from companies_house_abm.abm.agents.bank import Bank
+    from companies_house_abm.abm.agents.household import Household
+    from companies_house_abm.abm.assets.property import Property
+    from companies_house_abm.abm.config import (
+        BankConfig,
+        HousingMarketConfig,
+        MortgageConfig,
+    )
+    from companies_house_abm.abm.markets.housing import HousingMarket
+
+    mo.md("## 1. Market Configuration")
+    return (
+        Bank,
+        BankConfig,
+        Household,
+        HousingMarket,
+        HousingMarketConfig,
+        MortgageConfig,
+        Property,
+        np,
+        plt,
+    )
+
+
+@app.cell
+def _(mo):
+    # --- Market mechanism parameters ---
+    search_intensity = mo.ui.slider(
+        1, 30, value=10, step=1, label="Search intensity (properties visited per buyer)"
+    )
+    price_reduction = mo.ui.slider(
+        0.01, 0.30, value=0.10, step=0.01, label="Price reduction rate per period"
+    )
+    max_months = mo.ui.slider(
+        2, 12, value=6, step=1, label="Max months listed before delist"
+    )
+    initial_markup = mo.ui.slider(
+        0.00, 0.20, value=0.05, step=0.01, label="Initial asking price markup"
+    )
+    mo.md(
+        f"""
+        ### Market Mechanism Parameters
+
+        {search_intensity}
+        {price_reduction}
+        {max_months}
+        {initial_markup}
+        """
+    )
+    return initial_markup, max_months, price_reduction, search_intensity
+
+
+@app.cell
+def _(mo):
+    # --- Mortgage policy parameters ---
+    max_ltv = mo.ui.slider(
+        0.50, 1.00, value=0.90, step=0.05, label="Max LTV (loan-to-value)"
+    )
+    max_dti = mo.ui.slider(
+        2.0, 7.0, value=4.5, step=0.25, label="Max DTI (debt-to-income multiple)"
+    )
+    mo.md(
+        f"""
+        ### Mortgage Policy Parameters (FPC toolkit)
+
+        {max_ltv}
+        {max_dti}
+        """
+    )
+    return max_dti, max_ltv
+
+
+@app.cell
+def _(mo):
+    # --- Population parameters ---
+    n_properties = mo.ui.slider(
+        20, 200, value=80, step=10, label="Number of properties"
+    )
+    n_buyers = mo.ui.slider(5, 80, value=30, step=5, label="Number of buyer households")
+    listing_fraction = mo.ui.slider(
+        0.05,
+        0.50,
+        value=0.20,
+        step=0.05,
+        label="Fraction of properties initially listed",
+    )
+    buyer_wealth_k = mo.ui.slider(
+        10, 100, value=40, step=5, label="Mean buyer wealth (£k)"
+    )
+    buyer_wage_k = mo.ui.slider(
+        1, 8, value=3, step=0.5, label="Mean buyer monthly wage (£k)"
+    )
+    mean_price_k = mo.ui.slider(
+        100, 500, value=250, step=25, label="Mean property price (£k)"
+    )
+    mo.md(
+        f"""
+        ### Population Parameters
+
+        {n_properties}
+        {n_buyers}
+        {listing_fraction}
+        {buyer_wealth_k}
+        {buyer_wage_k}
+        {mean_price_k}
+        """
+    )
+    return (
+        buyer_wage_k,
+        buyer_wealth_k,
+        listing_fraction,
+        mean_price_k,
+        n_buyers,
+        n_properties,
+    )
+
+
+@app.cell
+def _(mo):
+    # --- Simulation parameters ---
+    n_periods = mo.ui.slider(
+        10, 60, value=24, step=2, label="Simulation periods (months)"
+    )
+    seed = mo.ui.number(start=0, stop=999, value=42, label="Random seed")
+    mo.md(
+        f"""
+        ### Simulation Parameters
+
+        {n_periods}
+        {seed}
+        """
+    )
+    return n_periods, seed
+
+
+@app.cell
+def _(
+    Bank,
+    BankConfig,
+    Household,
+    HousingMarket,
+    HousingMarketConfig,
+    MortgageConfig,
+    Property,
+    buyer_wage_k,
+    buyer_wealth_k,
+    initial_markup,
+    listing_fraction,
+    max_dti,
+    max_ltv,
+    max_months,
+    mean_price_k,
+    mo,
+    n_buyers,
+    n_periods,
+    n_properties,
+    np,
+    price_reduction,
+    search_intensity,
+    seed,
+):
+    rng = np.random.default_rng(int(seed.value))
+
+    # Build config objects
+    hm_config = HousingMarketConfig(
+        search_intensity=int(search_intensity.value),
+        price_reduction_rate=float(price_reduction.value),
+        max_months_listed=int(max_months.value),
+        initial_markup=float(initial_markup.value),
+    )
+    mc_config = MortgageConfig(
+        max_ltv=float(max_ltv.value),
+        max_dti=float(max_dti.value),
+    )
+    bank_config = BankConfig()
+
+    # --- Create properties ---
+    n_props = int(n_properties.value)
+    mean_price = float(mean_price_k.value) * 1_000.0
+    prices = rng.lognormal(mean=np.log(mean_price), sigma=0.35, size=n_props)
+    n_listed = max(1, int(n_props * float(listing_fraction.value)))
+    listed_mask = np.zeros(n_props, dtype=bool)
+    listed_mask[:n_listed] = True
+    rng.shuffle(listed_mask)
+
+    properties: list[Property] = []
+    for i, (price, on_mkt) in enumerate(zip(prices, listed_mask, strict=True)):
+        p = Property(
+            property_id=f"prop_{i}",
+            market_value=float(price),
+            on_market=bool(on_mkt),
+            asking_price=float(price) * (1.0 + hm_config.initial_markup)
+            if on_mkt
+            else 0.0,
+            quality=float(rng.uniform(0.2, 0.9)),
+        )
+        properties.append(p)
+
+    # --- Create households (mix of buyers and owner-sellers) ---
+    mean_wealth = float(buyer_wealth_k.value) * 1_000.0
+    mean_wage = float(buyer_wage_k.value) * 1_000.0
+
+    n_buy = int(n_buyers.value)
+    households: list[Household] = []
+
+    # Buyer households
+    for _ in range(n_buy):
+        wealth = float(max(1_000.0, rng.lognormal(np.log(mean_wealth), 0.8)))
+        wage = float(max(500.0, rng.normal(mean_wage, mean_wage * 0.3)))
+        hh = Household(income=wage * 12.0, wealth=wealth, mpc=0.8)
+        hh.employed = True
+        hh.wage = wage
+        hh.tenure = "renter"
+        hh.wants_to_buy = True
+        hh.months_searching = 0
+        households.append(hh)
+
+    # Owner-seller households (one per listed property)
+    for prop in properties:
+        if prop.on_market:
+            owner = Household(income=mean_wage * 12.0, wealth=50_000.0, mpc=0.7)
+            owner.employed = True
+            owner.wage = mean_wage
+            owner.tenure = "owner_occupier"
+            owner.property_id = prop.property_id
+            prop.owner_id = owner.agent_id
+            owner.wants_to_sell = True
+            households.append(owner)
+
+    # --- Create a single representative bank ---
+    bank = Bank(
+        capital=50_000_000.0,
+        reserves=10_000_000.0,
+        loans=200_000_000.0,
+        deposits=180_000_000.0,
+        config=bank_config,
+        mortgage_config=mc_config,
+    )
+    bank.mortgage_rate = 0.045
+
+    # --- Run simulation ---
+    market = HousingMarket(config=hm_config)
+    mortgages: list = []
+
+    history: list[dict] = []
+    for period in range(int(n_periods.value)):
+        market.set_agents(properties, households, [bank], mortgages, rng=rng)
+        market.set_period(period)
+        state = market.clear()
+        history.append({"period": period, **state})
+
+    mo.md(
+        f"**Simulation complete** — {len(history)} periods, {len(mortgages)} mortgages originated."
+    )
+    return (
+        bank,
+        bank_config,
+        history,
+        hm_config,
+        households,
+        market,
+        mc_config,
+        mortgages,
+        n_buy,
+        n_listed,
+        n_props,
+        period,
+        properties,
+        rng,
+    )
+
+
+@app.cell
+def _(history, mo, plt):
+    periods = [h["period"] for h in history]
+    avg_prices = [h["average_price"] for h in history]
+    transactions = [h["transactions"] for h in history]
+    listings = [h["listings"] for h in history]
+    homeownership = [h["homeownership_rate"] for h in history]
+    months_supply = [h["months_supply"] for h in history]
+    hpi = [h["house_price_inflation"] * 100 for h in history]
+
+    fig, axes = plt.subplots(2, 3, figsize=(14, 8))
+    fig.suptitle("Housing Market Dynamics", fontsize=14, fontweight="bold")
+
+    # Average price
+    axes[0, 0].plot(periods, avg_prices, color="steelblue", linewidth=2)
+    axes[0, 0].set_title("Average House Price")
+    axes[0, 0].set_xlabel("Period (months)")
+    axes[0, 0].set_ylabel("£")
+    axes[0, 0].yaxis.set_major_formatter(
+        plt.FuncFormatter(lambda x, _: f"£{x / 1000:.0f}k")
+    )
+
+    # Transactions per period
+    axes[0, 1].bar(periods, transactions, color="coral", alpha=0.7)
+    axes[0, 1].set_title("Transactions per Period")
+    axes[0, 1].set_xlabel("Period (months)")
+    axes[0, 1].set_ylabel("Count")
+
+    # Listings
+    axes[0, 2].plot(periods, listings, color="darkorange", linewidth=2)
+    axes[0, 2].set_title("Active Listings")
+    axes[0, 2].set_xlabel("Period (months)")
+    axes[0, 2].set_ylabel("Count")
+
+    # Homeownership rate
+    axes[1, 0].plot(
+        periods, [r * 100 for r in homeownership], color="green", linewidth=2
+    )
+    axes[1, 0].set_title("Homeownership Rate")
+    axes[1, 0].set_xlabel("Period (months)")
+    axes[1, 0].set_ylabel("%")
+    axes[1, 0].set_ylim(0, 100)
+
+    # Months of supply
+    axes[1, 1].plot(periods, months_supply, color="purple", linewidth=2)
+    axes[1, 1].axhline(
+        6, color="red", linestyle="--", alpha=0.6, label="6-month benchmark"
+    )
+    axes[1, 1].set_title("Months of Supply")
+    axes[1, 1].set_xlabel("Period (months)")
+    axes[1, 1].set_ylabel("Months")
+    axes[1, 1].legend()
+
+    # House price inflation
+    axes[1, 2].bar(
+        periods,
+        hpi,
+        color=["green" if v >= 0 else "red" for v in hpi],
+        alpha=0.7,
+    )
+    axes[1, 2].axhline(0, color="black", linewidth=0.8)
+    axes[1, 2].set_title("Monthly House Price Inflation")
+    axes[1, 2].set_xlabel("Period (months)")
+    axes[1, 2].set_ylabel("%")
+
+    plt.tight_layout()
+    mo.pyplot(fig)
+    return (
+        avg_prices,
+        fig,
+        homeownership,
+        hpi,
+        listings,
+        months_supply,
+        periods,
+        transactions,
+    )
+
+
+@app.cell
+def _(history, mo, mortgages):
+    total_tx = sum(h["transactions"] for h in history)
+    total_lending = sum(h["total_mortgage_lending"] for h in history)
+    final_ownership = history[-1]["homeownership_rate"] * 100 if history else 0.0
+    final_price = history[-1]["average_price"] if history else 0.0
+    final_supply = history[-1]["months_supply"] if history else 0.0
+
+    mo.md(
+        f"""
+        ## 2. Summary Statistics
+
+        | Metric | Value |
+        |--------|-------|
+        | Total transactions | {total_tx} |
+        | Total mortgage lending | £{total_lending / 1_000_000:.1f}m |
+        | Mortgages originated | {len(mortgages)} |
+        | Final homeownership rate | {final_ownership:.1f}% |
+        | Final average price | £{final_price / 1_000:.0f}k |
+        | Final months of supply | {final_supply:.1f} |
+        """
+    )
+    return final_ownership, final_price, final_supply, total_lending, total_tx
+
+
+@app.cell
+def _(mo, mortgages, plt):
+    mo.md("## 3. Mortgage Book Analysis")
+
+    if mortgages:
+        ltvs = [m.ltv_at_origination for m in mortgages]
+        dtis = [m.dti_at_origination for m in mortgages]
+        principals = [m.principal for m in mortgages]
+
+        fig2, axes2 = plt.subplots(1, 3, figsize=(14, 4))
+        fig2.suptitle(
+            "Originated Mortgage Characteristics", fontsize=13, fontweight="bold"
+        )
+
+        axes2[0].hist(ltvs, bins=20, color="steelblue", alpha=0.8, edgecolor="white")
+        axes2[0].axvline(0.90, color="red", linestyle="--", label="LTV cap")
+        axes2[0].set_title("Loan-to-Value Distribution")
+        axes2[0].set_xlabel("LTV")
+        axes2[0].set_ylabel("Count")
+        axes2[0].legend()
+
+        axes2[1].hist(dtis, bins=20, color="coral", alpha=0.8, edgecolor="white")
+        axes2[1].axvline(4.5, color="red", linestyle="--", label="DTI cap")
+        axes2[1].set_title("Debt-to-Income Distribution")
+        axes2[1].set_xlabel("DTI multiple")
+        axes2[1].set_ylabel("Count")
+        axes2[1].legend()
+
+        axes2[2].hist(
+            [p / 1_000 for p in principals],
+            bins=20,
+            color="green",
+            alpha=0.8,
+            edgecolor="white",
+        )
+        axes2[2].set_title("Mortgage Size Distribution")
+        axes2[2].set_xlabel("Principal (£k)")
+        axes2[2].set_ylabel("Count")
+
+        plt.tight_layout()
+        mo.pyplot(fig2)
+    else:
+        mo.md("_No mortgages originated in this simulation run._")
+    return
+
+
+@app.cell
+def _(mo, properties):
+    mo.md("## 4. Property State at End of Simulation")
+
+    n_sold = sum(1 for p in properties if not p.on_market and p.owner_id is not None)
+    n_still_listed = sum(1 for p in properties if p.on_market)
+    n_vacant = sum(1 for p in properties if not p.on_market and p.owner_id is None)
+    sold_prices = [
+        p.last_transaction_price for p in properties if p.last_transaction_period > 0
+    ]
+    avg_sold_price = sum(sold_prices) / len(sold_prices) if sold_prices else 0.0
+
+    mo.md(
+        f"""
+        | Status | Count |
+        |--------|-------|
+        | Sold / owner-occupied | {n_sold} |
+        | Still listed | {n_still_listed} |
+        | Unlisted / vacant | {n_vacant} |
+        | Average transaction price | £{avg_sold_price / 1_000:.0f}k |
+        """
+    )
+    return avg_sold_price, n_sold, n_still_listed, n_vacant, sold_prices
+
+
+@app.cell
+def _(mo, plt, properties):
+    sold_props = [p for p in properties if p.last_transaction_period > 0]
+    unsold_props = [p for p in properties if p.last_transaction_period == 0]
+
+    if sold_props or unsold_props:
+        fig3, ax3 = plt.subplots(figsize=(9, 5))
+        if sold_props:
+            ax3.scatter(
+                [p.quality for p in sold_props],
+                [p.last_transaction_price / 1_000 for p in sold_props],
+                color="steelblue",
+                alpha=0.6,
+                label=f"Sold ({len(sold_props)})",
+                s=40,
+            )
+        if unsold_props:
+            ax3.scatter(
+                [p.quality for p in unsold_props],
+                [p.market_value / 1_000 for p in unsold_props],
+                color="lightcoral",
+                alpha=0.4,
+                marker="x",
+                label=f"Unsold ({len(unsold_props)})",
+                s=40,
+            )
+        ax3.set_title("Quality vs. Price (sold vs. unsold)")
+        ax3.set_xlabel("Property quality score")
+        ax3.set_ylabel("Price (£k)")
+        ax3.legend()
+        plt.tight_layout()
+        mo.pyplot(fig3)
+    else:
+        mo.md("_No properties to plot._")
+    return ax3, fig3, sold_props, unsold_props
+
+
+@app.cell
+def _(avg_prices, mo, plt):
+    mo.md("## 5. Price Expectations & Momentum")
+
+    if len(avg_prices) > 3:
+        returns = [
+            (avg_prices[i] / avg_prices[i - 1] - 1.0) * 100
+            for i in range(1, len(avg_prices))
+        ]
+        window = min(6, len(returns) // 2)
+        rolling_avg = [
+            sum(returns[max(0, i - window) : i + 1]) / min(i + 1, window + 1)
+            for i in range(len(returns))
+        ]
+
+        fig4, ax4 = plt.subplots(figsize=(10, 4))
+        ax4.bar(
+            range(len(returns)),
+            returns,
+            color=["green" if r >= 0 else "red" for r in returns],
+            alpha=0.6,
+            label="Monthly return",
+        )
+        ax4.plot(
+            rolling_avg, color="navy", linewidth=2, label=f"{window}-period moving avg"
+        )
+        ax4.axhline(0, color="black", linewidth=0.8)
+        ax4.set_title("Monthly House Price Returns")
+        ax4.set_xlabel("Period")
+        ax4.set_ylabel("Return (%)")
+        ax4.legend()
+        plt.tight_layout()
+        mo.pyplot(fig4)
+    else:
+        mo.md("_Run more periods to see return dynamics._")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
     "hatch>=1.16.3",
     "prek>=0.1.0",
     "pysentry-rs>=0.1.0",
+    "cryptography>=46.0.6",
+    "pygments>=2.20.0",
+    "requests>=2.33.0",
 ]
 docs = [
     "mkdocs>=1.6.0",

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -25,11 +25,7 @@ Requirements:
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-
-# Allow running from project root without installing
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from tests.test_abm_performance import (
     BENCH_PERIODS,

--- a/src/companies_house_abm/abm/README.md
+++ b/src/companies_house_abm/abm/README.md
@@ -4,21 +4,27 @@ This module implements an agent-based model of the UK economy using Companies Ho
 
 ## Overview
 
-The ABM models the UK economy as a complex adaptive system with five agent types interacting through three markets:
+The ABM models the UK economy as a complex adaptive system with five agent types interacting through four markets:
 
 **Agents:**
 
 - **Firm** (`agents/firm.py`): Productive agents with balance sheets, pricing, production and employment decisions
-- **Household** (`agents/household.py`): Labour supply, consumption and savings
-- **Bank** (`agents/bank.py`): Credit provision with Basel III capital constraints
+- **Household** (`agents/household.py`): Labour supply, consumption, savings, and housing decisions (buy/rent, mortgage payments)
+- **Bank** (`agents/bank.py`): Credit provision and mortgage lending with Basel III capital constraints and FPC macroprudential tools
 - **Central Bank** (`agents/central_bank.py`): Monetary policy via Taylor rule
 - **Government** (`agents/government.py`): Taxation, spending and fiscal rule
+
+**Assets:**
+
+- **Property** (`assets/property.py`): Housing units with region, type, quality, and aspiration-level pricing
+- **Mortgage** (`assets/mortgage.py`): Loan contracts with amortisation, arrears tracking, and LTV/DTI metrics
 
 **Markets:**
 
 - **Goods Market** (`markets/goods.py`): Firms post prices; households and government purchase
 - **Labour Market** (`markets/labor.py`): Vacancy posting, job search and matching with frictions
 - **Credit Market** (`markets/credit.py`): Firms borrow from banks with risk-based pricing
+- **Housing Market** (`markets/housing.py`): Bilateral matching with aspiration-level pricing (Farmer 2025)
 
 ## Installation
 
@@ -82,14 +88,18 @@ abm/
 │   ├── base.py          # Abstract BaseAgent class
 │   ├── firm.py          # Firm agent
 │   ├── household.py     # Household agent
-│   ├── bank.py          # Bank agent
+│   ├── bank.py          # Bank agent (incl. mortgage lending)
 │   ├── central_bank.py  # Central bank agent
 │   └── government.py    # Government agent
+├── assets/
+│   ├── property.py      # Property dataclass
+│   └── mortgage.py      # Mortgage dataclass
 └── markets/
     ├── base.py          # Abstract BaseMarket class
     ├── goods.py         # Goods market
     ├── labor.py         # Labour market
-    └── credit.py        # Credit market
+    ├── credit.py        # Credit market
+    └── housing.py       # Housing market (bilateral matching)
 ```
 
 ## Interactive Notebooks
@@ -110,7 +120,9 @@ uv run marimo edit notebooks/ecosystem.py
 
 ## References
 
-1. Farmer, J.D. & Foley, D. (2009). "The economy needs agent-based modelling." *Nature*
-2. Delli Gatti, D. et al. (2011). "Macroeconomics from the Bottom-up." Springer
-3. Dawid, H. & Delli Gatti, D. (2018). "Agent-Based Macroeconomics." *Handbook of Computational Economics*
-4. Godley, W. & Lavoie, M. (2007). "Monetary Economics: An Integrated Approach." Palgrave
+1. Farmer, J.D. (2025). "Quantitative agent-based models: a promising alternative for macroeconomics." *Oxford Review of Economic Policy*
+2. Axtell, R.L. & Farmer, J.D. (2025). "Agent-Based Modeling in Economics and Finance: Past, Present, and Future." *Journal of Economic Literature*
+3. Baptista, R. et al. (2016). "Macroprudential policy in an agent-based model of the UK housing market." Staff Working Paper No. 619, Bank of England
+4. Farmer, J.D. & Foley, D. (2009). "The economy needs agent-based modelling." *Nature*
+5. Delli Gatti, D. et al. (2011). "Macroeconomics from the Bottom-up." Springer
+6. Godley, W. & Lavoie, M. (2007). "Monetary Economics: An Integrated Approach." Palgrave

--- a/src/companies_house_abm/abm/agents/bank.py
+++ b/src/companies_house_abm/abm/agents/bank.py
@@ -1,7 +1,7 @@
 """Bank agent for the ABM.
 
-Banks accept deposits, extend credit to firms, and must satisfy
-regulatory capital and reserve requirements.
+Banks accept deposits, extend credit to firms, originate mortgages,
+and must satisfy regulatory capital and reserve requirements.
 """
 
 from __future__ import annotations
@@ -13,7 +13,12 @@ from companies_house_abm.abm.agents.base import BaseAgent
 if TYPE_CHECKING:
     from typing import Any
 
-    from companies_house_abm.abm.config import BankBehaviorConfig, BankConfig
+    from companies_house_abm.abm.assets.mortgage import Mortgage
+    from companies_house_abm.abm.config import (
+        BankBehaviorConfig,
+        BankConfig,
+        MortgageConfig,
+    )
 
 
 class Bank(BaseAgent):
@@ -39,6 +44,7 @@ class Bank(BaseAgent):
         deposits: float = 0.0,
         config: BankConfig | None = None,
         behavior: BankBehaviorConfig | None = None,
+        mortgage_config: MortgageConfig | None = None,
     ) -> None:
         super().__init__(agent_id)
         self.capital = capital
@@ -51,8 +57,15 @@ class Bank(BaseAgent):
         self._interest_income: float = 0.0
         self._interest_expense: float = 0.0
 
+        # Mortgage state
+        self.mortgage_book: float = 0.0
+        self.mortgage_npl: float = 0.0
+        self.mortgage_rate: float = 0.04
+        self.mortgage_count: int = 0
+
         self._config = config
         self._behavior = behavior
+        self._mortgage_config = mortgage_config
 
     # ------------------------------------------------------------------
     # Regulatory ratios
@@ -62,7 +75,12 @@ class Bank(BaseAgent):
     def capital_ratio(self) -> float:
         """Capital adequacy ratio (capital / risk-weighted assets)."""
         rw = self._config.risk_weight if self._config else 1.0
-        risk_weighted = self.loans * rw
+        mortgage_rw = (
+            self._mortgage_config.mortgage_risk_weight
+            if self._mortgage_config
+            else 0.35
+        )
+        risk_weighted = self.loans * rw + self.mortgage_book * mortgage_rw
         if risk_weighted <= 0:
             return 1.0
         return self.capital / risk_weighted
@@ -189,6 +207,178 @@ class Bank(BaseAgent):
         self.loans = max(self.loans - amount, 0.0)
 
     # ------------------------------------------------------------------
+    # Mortgage interface used by the housing market
+    # ------------------------------------------------------------------
+
+    def set_mortgage_rate(self, policy_rate: float) -> None:
+        """Set the mortgage rate based on the policy rate.
+
+        Args:
+            policy_rate: Current central bank policy rate.
+        """
+        spread = (
+            self._mortgage_config.mortgage_spread if self._mortgage_config else 0.015
+        )
+        risk = self._behavior.risk_premium_sensitivity if self._behavior else 0.05
+        npl_ratio = (
+            self.mortgage_npl / self.mortgage_book if self.mortgage_book > 0 else 0.0
+        )
+        self.mortgage_rate = policy_rate + spread + risk * npl_ratio
+
+    def evaluate_mortgage(
+        self,
+        annual_income: float,
+        deposit: float,
+        property_value: float,
+    ) -> bool:
+        """Decide whether to approve a mortgage application.
+
+        Applies FPC macroprudential checks: LTV cap, DTI limit, and
+        affordability stress test.
+
+        Args:
+            annual_income: Borrower's gross annual income.
+            deposit: Cash deposit available.
+            property_value: Value of the property to purchase.
+
+        Returns:
+            True if the mortgage is approved.
+        """
+        if not self.meets_capital_requirement:
+            return False
+
+        loan_amount = property_value - deposit
+        if loan_amount <= 0:
+            return True  # cash purchase, no mortgage needed
+
+        max_ltv = self._mortgage_config.max_ltv if self._mortgage_config else 0.90
+        max_dti = self._mortgage_config.max_dti if self._mortgage_config else 4.5
+        stress_buffer = (
+            self._mortgage_config.stress_test_buffer if self._mortgage_config else 0.03
+        )
+
+        # LTV check
+        ltv = loan_amount / property_value
+        if ltv > max_ltv:
+            return False
+
+        # DTI check
+        if annual_income <= 0:
+            return False
+        dti = loan_amount / annual_income
+        if dti > max_dti:
+            return False
+
+        # Affordability stress test: can they pay at rate + buffer?
+        stressed_rate = self.mortgage_rate + stress_buffer
+        monthly_rate = stressed_rate / 12.0
+        term = (
+            self._mortgage_config.default_term_months if self._mortgage_config else 300
+        )
+        if monthly_rate > 0:
+            factor = (1.0 + monthly_rate) ** term
+            stressed_payment = loan_amount * monthly_rate * factor / (factor - 1.0)
+        else:
+            stressed_payment = loan_amount / term
+
+        monthly_income = annual_income / 12.0
+        # Affordability: stressed payment should be < 40% of gross monthly income
+        return stressed_payment < monthly_income * 0.40
+
+    def originate_mortgage(
+        self,
+        borrower_id: str,
+        property_id: str,
+        loan_amount: float,
+        property_value: float,
+        annual_income: float,
+        period: int,
+    ) -> Mortgage:
+        """Create a new mortgage and update the bank's books.
+
+        Args:
+            borrower_id: Household agent_id.
+            property_id: Property being purchased.
+            loan_amount: Principal amount.
+            property_value: Property value.
+            annual_income: Borrower's annual income.
+            period: Current simulation period.
+
+        Returns:
+            A new :class:`Mortgage` instance.
+        """
+        from companies_house_abm.abm.assets.mortgage import Mortgage
+
+        term = (
+            self._mortgage_config.default_term_months if self._mortgage_config else 300
+        )
+        rate_type = "fixed"
+        if self._mortgage_config:
+            import random
+
+            rate_type = (
+                "fixed"
+                if random.random() < self._mortgage_config.fixed_rate_share
+                else "variable"
+            )
+
+        mortgage = Mortgage(
+            borrower_id=borrower_id,
+            lender_id=self.agent_id,
+            property_id=property_id,
+            principal=loan_amount,
+            outstanding=loan_amount,
+            interest_rate=self.mortgage_rate,
+            rate_type=rate_type,
+            term_months=term,
+            remaining_months=term,
+            ltv_at_origination=(
+                loan_amount / property_value if property_value > 0 else 0
+            ),
+            dti_at_origination=(
+                loan_amount / annual_income if annual_income > 0 else 0
+            ),
+            start_period=period,
+        )
+
+        self.mortgage_book += loan_amount
+        self.mortgage_count += 1
+        self.deposits += loan_amount  # loan creates deposit
+        return mortgage
+
+    def assess_foreclosure(self, mortgage: Mortgage) -> bool:
+        """Decide whether to foreclose on a mortgage in arrears.
+
+        Args:
+            mortgage: The mortgage to assess.
+
+        Returns:
+            True if the bank decides to foreclose.
+        """
+        threshold = (
+            self._mortgage_config.foreclosure_threshold if self._mortgage_config else 3
+        )
+        return mortgage.in_arrears and mortgage.arrears_months >= threshold
+
+    def record_mortgage_default(self, amount: float) -> None:
+        """Record a mortgage default.
+
+        Args:
+            amount: Outstanding balance of the defaulted mortgage.
+        """
+        self.mortgage_npl += amount
+        self.mortgage_book = max(self.mortgage_book - amount, 0.0)
+        self.mortgage_count = max(self.mortgage_count - 1, 0)
+
+    def record_mortgage_repayment(self, amount: float) -> None:
+        """Record a mortgage principal repayment.
+
+        Args:
+            amount: The principal portion repaid.
+        """
+        self.mortgage_book = max(self.mortgage_book - amount, 0.0)
+
+    # ------------------------------------------------------------------
     # State reporting
     # ------------------------------------------------------------------
 
@@ -205,4 +395,8 @@ class Bank(BaseAgent):
             "interest_rate": self.interest_rate,
             "capital_ratio": self.capital_ratio,
             "profit": self.profit,
+            "mortgage_book": self.mortgage_book,
+            "mortgage_npl": self.mortgage_npl,
+            "mortgage_rate": self.mortgage_rate,
+            "mortgage_count": self.mortgage_count,
         }

--- a/src/companies_house_abm/abm/agents/household.py
+++ b/src/companies_house_abm/abm/agents/household.py
@@ -1,6 +1,7 @@
 """Household agent for the ABM.
 
-Households supply labour, consume goods, and accumulate savings.
+Households supply labour, consume goods, accumulate savings, and make
+housing decisions (rent vs. buy).
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ from companies_house_abm.abm.agents.base import BaseAgent
 if TYPE_CHECKING:
     from typing import Any
 
+    from companies_house_abm.abm.assets.mortgage import Mortgage
     from companies_house_abm.abm.config import HouseholdBehaviorConfig
 
 
@@ -51,6 +53,17 @@ class Household(BaseAgent):
         self.savings: float = 0.0
         self.transfer_income: float = 0.0
 
+        # Housing state
+        self.tenure: str = "renter"  # "owner_occupier", "renter", "homeless"
+        self.property_id: str | None = None
+        self.mortgage: Mortgage | None = None
+        self.rent: float = 0.0  # monthly rent payment
+        self.housing_wealth: float = 0.0  # property value - mortgage outstanding
+        self.price_expectation: float = 0.0
+        self.wants_to_buy: bool = False
+        self.wants_to_sell: bool = False
+        self.months_searching: int = 0
+
         self._behavior = behavior
 
     # ------------------------------------------------------------------
@@ -61,10 +74,12 @@ class Household(BaseAgent):
         """Execute one period of household behaviour.
 
         1. Receive income (wage if employed, transfers if not).
-        2. Decide consumption.
-        3. Save the remainder.
+        2. Make housing payment (rent or mortgage).
+        3. Decide consumption from remaining disposable income.
+        4. Save the remainder.
         """
         self._receive_income()
+        self._make_housing_payment()
         self._consume()
         self._save()
 
@@ -73,11 +88,30 @@ class Household(BaseAgent):
         wage_income = self.wage if self.employed else 0.0
         self.income = wage_income + self.transfer_income
 
+    def _make_housing_payment(self) -> None:
+        """Deduct housing costs from income.
+
+        For owner-occupiers with a mortgage, amortize the mortgage and
+        deduct the payment.  For renters, deduct rent.  If the household
+        cannot afford the payment, the mortgage enters arrears.
+        """
+        if self.mortgage is not None:
+            payment = self.mortgage.monthly_payment
+            if self.income + self.wealth >= payment:
+                self.mortgage.amortize()
+                self.mortgage.record_payment_made()
+                self.income -= payment
+            else:
+                self.mortgage.record_missed_payment()
+        elif self.tenure == "renter" and self.rent > 0:
+            actual = min(self.rent, self.income + self.wealth)
+            self.income -= actual
+
     def _consume(self) -> None:
         """Determine consumption spending.
 
-        Uses a consumption function that depends on current income and
-        wealth, weighted by a smoothing parameter.
+        Uses a consumption function that depends on current (post-housing)
+        income and wealth, weighted by a smoothing parameter.
         """
         smoothing = self._behavior.consumption_smoothing if self._behavior else 0.7
         # Consumption out of income and a fraction of wealth
@@ -91,6 +125,68 @@ class Household(BaseAgent):
         """Save unspent income."""
         self.savings = self.income - self.consumption
         self.wealth += self.savings
+
+    # ------------------------------------------------------------------
+    # Housing decisions (used by the housing market)
+    # ------------------------------------------------------------------
+
+    def decide_buy_or_rent(
+        self,
+        average_price: float,
+        mortgage_rate: float,
+        rental_yield: float,
+        price_history: list[float] | None = None,
+        backward_weight: float = 0.65,
+        lookback: int = 12,
+    ) -> None:
+        """Decide whether to seek to buy a property.
+
+        Compares expected annual cost of owning (mortgage payment +
+        maintenance - expected appreciation) vs. renting.  Follows
+        Farmer (2025): backward-looking price expectations drive the
+        buy/rent decision.
+        """
+        # Only renters consider buying
+        if self.tenure != "renter":
+            self.wants_to_buy = False
+            return
+
+        # Price expectation from recent trend
+        if price_history and len(price_history) >= 2:
+            recent = price_history[-min(lookback, len(price_history)) :]
+            backward_trend = (recent[-1] - recent[0]) / max(recent[0], 1.0)
+            backward_trend /= max(len(recent) - 1, 1)
+        else:
+            backward_trend = 0.0
+        forward_trend = 0.02 / 12.0  # ~2% annual fundamental growth
+
+        expected_monthly_appreciation = (
+            backward_weight * backward_trend + (1.0 - backward_weight) * forward_trend
+        )
+        self.price_expectation = average_price * (1.0 + expected_monthly_appreciation)
+
+        # Cost comparison: monthly cost of owning vs renting
+        monthly_mortgage = average_price * 0.8 * mortgage_rate / 12.0
+        monthly_maintenance = average_price * 0.01 / 12.0
+        monthly_appreciation = average_price * expected_monthly_appreciation
+        cost_of_owning = monthly_mortgage + monthly_maintenance - monthly_appreciation
+
+        cost_of_renting = average_price * rental_yield / 12.0
+
+        # Can they afford a deposit? (20% of average price)
+        deposit_needed = average_price * 0.10
+        can_afford_deposit = self.wealth >= deposit_needed
+
+        self.wants_to_buy = can_afford_deposit and cost_of_owning < cost_of_renting
+
+    def update_housing_wealth(self, property_value: float) -> None:
+        """Recalculate housing wealth from current property value."""
+        if self.tenure == "owner_occupier" and self.mortgage is not None:
+            self.housing_wealth = property_value - self.mortgage.outstanding
+        elif self.tenure == "owner_occupier":
+            self.housing_wealth = property_value
+        else:
+            self.housing_wealth = 0.0
 
     # ------------------------------------------------------------------
     # Employment interface used by the labor market
@@ -146,4 +242,9 @@ class Household(BaseAgent):
             "employer_id": self.employer_id,
             "wage": self.wage,
             "mpc": self.mpc,
+            "tenure": self.tenure,
+            "property_id": self.property_id,
+            "rent": self.rent,
+            "housing_wealth": self.housing_wealth,
+            "has_mortgage": self.mortgage is not None,
         }

--- a/src/companies_house_abm/abm/assets/__init__.py
+++ b/src/companies_house_abm/abm/assets/__init__.py
@@ -1,0 +1,11 @@
+"""Non-agent asset classes for the ABM (properties, mortgages)."""
+
+from __future__ import annotations
+
+from companies_house_abm.abm.assets.mortgage import Mortgage
+from companies_house_abm.abm.assets.property import Property
+
+__all__ = [
+    "Mortgage",
+    "Property",
+]

--- a/src/companies_house_abm/abm/assets/mortgage.py
+++ b/src/companies_house_abm/abm/assets/mortgage.py
@@ -1,0 +1,107 @@
+"""Mortgage asset class for the housing market."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Mortgage:
+    """A mortgage loan linking a borrower (household) to a lender (bank).
+
+    Both the :class:`Bank` and :class:`Household` reference this object by
+    its ``mortgage_id``.  The canonical collection of active mortgages is
+    maintained by the :class:`HousingMarket`.
+    """
+
+    # Identity
+    mortgage_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    borrower_id: str = ""
+    lender_id: str = ""
+    property_id: str = ""
+
+    # Loan terms
+    principal: float = 0.0  # original loan amount
+    outstanding: float = 0.0  # current outstanding balance
+    interest_rate: float = 0.04  # annual rate
+    rate_type: str = "fixed"  # "fixed" or "variable"
+    term_months: int = 300  # 25 years
+    remaining_months: int = 300
+    monthly_payment: float = 0.0  # required monthly payment
+
+    # Risk metrics at origination
+    ltv_at_origination: float = 0.0  # loan-to-value
+    dti_at_origination: float = 0.0  # debt-to-income multiple
+
+    # Arrears tracking
+    in_arrears: bool = False
+    arrears_months: int = 0
+
+    # Timing
+    start_period: int = 0
+
+    def __post_init__(self) -> None:
+        """Calculate monthly payment if not already set."""
+        if self.monthly_payment == 0.0 and self.principal > 0:
+            self.monthly_payment = self._calculate_monthly_payment()
+
+    def _calculate_monthly_payment(self) -> float:
+        """Standard annuity formula for monthly mortgage payment."""
+        if self.term_months <= 0:
+            return 0.0
+        monthly_rate = self.interest_rate / 12.0
+        if monthly_rate == 0.0:
+            return self.principal / self.term_months
+        factor = (1.0 + monthly_rate) ** self.term_months
+        return self.principal * monthly_rate * factor / (factor - 1.0)
+
+    def current_ltv(self, property_value: float) -> float:
+        """Current loan-to-value ratio."""
+        if property_value <= 0:
+            return float("inf")
+        return self.outstanding / property_value
+
+    def amortize(self) -> float:
+        """Process one month of the mortgage.
+
+        Returns the monthly payment amount.  Reduces the outstanding
+        balance by the principal portion.
+        """
+        if self.remaining_months <= 0 or self.outstanding <= 0:
+            return 0.0
+
+        monthly_rate = self.interest_rate / 12.0
+        interest_portion = self.outstanding * monthly_rate
+        principal_portion = self.monthly_payment - interest_portion
+
+        self.outstanding = max(0.0, self.outstanding - principal_portion)
+        self.remaining_months -= 1
+        return self.monthly_payment
+
+    def record_missed_payment(self) -> None:
+        """Record a missed mortgage payment."""
+        self.in_arrears = True
+        self.arrears_months += 1
+
+    def record_payment_made(self) -> None:
+        """Record a successful mortgage payment, resetting arrears counter."""
+        self.in_arrears = False
+        self.arrears_months = 0
+
+    def get_state(self) -> dict[str, object]:
+        """Return mortgage state for logging/analysis."""
+        return {
+            "mortgage_id": self.mortgage_id,
+            "borrower_id": self.borrower_id,
+            "lender_id": self.lender_id,
+            "property_id": self.property_id,
+            "outstanding": self.outstanding,
+            "interest_rate": self.interest_rate,
+            "rate_type": self.rate_type,
+            "remaining_months": self.remaining_months,
+            "monthly_payment": self.monthly_payment,
+            "ltv_at_origination": self.ltv_at_origination,
+            "in_arrears": self.in_arrears,
+            "arrears_months": self.arrears_months,
+        }

--- a/src/companies_house_abm/abm/assets/property.py
+++ b/src/companies_house_abm/abm/assets/property.py
@@ -1,0 +1,87 @@
+"""Property asset class for the housing market."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Property:
+    """A housing unit that can be owned, rented, or traded.
+
+    Properties are passive assets — they do not make decisions and have no
+    ``step()`` method.  Their state is updated by the :class:`HousingMarket`
+    during the market clearing phase.
+
+    Seller pricing follows *aspiration-level adaptation* (Farmer 2025): the
+    asking price starts above recent comparable sales and is gradually reduced
+    each period the property remains unsold.
+    """
+
+    # Identity
+    property_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    region: str = "south_east"
+    property_type: str = "terraced"  # detached, semi_detached, terraced, flat
+    quality: float = 0.5  # abstract index [0, 1]
+
+    # Valuation
+    market_value: float = 285_000.0  # current estimated value (GBP)
+    last_transaction_price: float = 285_000.0
+    last_transaction_period: int = 0
+
+    # Ownership
+    owner_id: str | None = None  # household agent_id, None if vacant
+    on_market: bool = False
+    asking_price: float = 0.0
+    months_listed: int = 0
+
+    # Rental
+    rental_value: float = 1_000.0  # monthly rent (GBP)
+    is_rented: bool = False
+    tenant_id: str | None = None
+
+    def list_for_sale(self, initial_markup: float = 0.05) -> None:
+        """Put the property on the market at a markup above market value."""
+        self.on_market = True
+        self.asking_price = self.market_value * (1.0 + initial_markup)
+        self.months_listed = 0
+
+    def reduce_price(self, reduction_rate: float = 0.10) -> None:
+        """Reduce the asking price after an unsold period."""
+        self.asking_price *= 1.0 - reduction_rate
+        self.months_listed += 1
+
+    def delist(self) -> None:
+        """Remove the property from the market."""
+        self.on_market = False
+        self.asking_price = 0.0
+        self.months_listed = 0
+
+    def sell(self, new_owner_id: str, sale_price: float, period: int) -> None:
+        """Record a sale transaction."""
+        self.owner_id = new_owner_id
+        self.last_transaction_price = sale_price
+        self.last_transaction_period = period
+        self.market_value = sale_price
+        self.on_market = False
+        self.asking_price = 0.0
+        self.months_listed = 0
+        self.is_rented = False
+        self.tenant_id = None
+
+    def get_state(self) -> dict[str, object]:
+        """Return property state for logging/analysis."""
+        return {
+            "property_id": self.property_id,
+            "region": self.region,
+            "property_type": self.property_type,
+            "quality": self.quality,
+            "market_value": self.market_value,
+            "on_market": self.on_market,
+            "asking_price": self.asking_price,
+            "months_listed": self.months_listed,
+            "is_rented": self.is_rented,
+            "owner_id": self.owner_id,
+            "tenant_id": self.tenant_id,
+        }

--- a/src/companies_house_abm/abm/config.py
+++ b/src/companies_house_abm/abm/config.py
@@ -167,6 +167,63 @@ class CreditMarketConfig:
 
 
 @dataclass(frozen=True)
+class PropertyConfig:
+    """Configuration for the housing stock."""
+
+    count: int = 12_000
+    regions: tuple[str, ...] = (
+        "london",
+        "south_east",
+        "east",
+        "south_west",
+        "west_midlands",
+        "east_midlands",
+        "north_west",
+        "north_east",
+        "yorkshire",
+        "scotland",
+        "wales",
+    )
+    types: tuple[str, ...] = ("detached", "semi_detached", "terraced", "flat")
+    type_shares: tuple[float, ...] = (0.16, 0.24, 0.28, 0.32)
+    average_price: float = 285_000.0
+
+
+@dataclass(frozen=True)
+class HousingMarketConfig:
+    """Configuration for the housing market mechanism.
+
+    The housing market uses bilateral matching with aspiration-level pricing,
+    following the Farmer/Geanakoplos approach (Farmer 2025).
+    """
+
+    search_intensity: int = 10
+    initial_markup: float = 0.05
+    price_reduction_rate: float = 0.10
+    max_months_listed: int = 6
+    backward_expectation_weight: float = 0.65
+    expectation_lookback: int = 12
+    transaction_cost: float = 0.05
+    maintenance_cost: float = 0.01
+    rental_yield: float = 0.045
+
+
+@dataclass(frozen=True)
+class MortgageConfig:
+    """Configuration for mortgage lending (FPC macroprudential toolkit)."""
+
+    max_ltv: float = 0.90
+    max_dti: float = 4.5
+    stress_test_buffer: float = 0.03
+    default_term_months: int = 300
+    fixed_rate_share: float = 0.75
+    fixed_rate_period: int = 24
+    mortgage_risk_weight: float = 0.35
+    foreclosure_threshold: int = 3
+    mortgage_spread: float = 0.015
+
+
+@dataclass(frozen=True)
 class ModelConfig:
     """Complete model configuration."""
 
@@ -185,6 +242,9 @@ class ModelConfig:
     goods_market: GoodsMarketConfig = field(default_factory=GoodsMarketConfig)
     labor_market: LaborMarketConfig = field(default_factory=LaborMarketConfig)
     credit_market: CreditMarketConfig = field(default_factory=CreditMarketConfig)
+    properties: PropertyConfig = field(default_factory=PropertyConfig)
+    housing_market: HousingMarketConfig = field(default_factory=HousingMarketConfig)
+    mortgage: MortgageConfig = field(default_factory=MortgageConfig)
 
 
 def _extract(raw: dict[str, Any], section: str, *keys: str) -> dict[str, Any]:
@@ -233,6 +293,22 @@ def load_config(path: Path | None = None) -> ModelConfig:
     # Handle size_classes key that's in YAML but not in the dataclass
     firms_raw = {k: v for k, v in firms_raw.items() if k != "size_classes"}
 
+    # Housing: properties, housing market, and mortgage config
+    properties_raw = agents.get("properties", {})
+    if "regions" in properties_raw and isinstance(properties_raw["regions"], list):
+        properties_raw = {**properties_raw, "regions": tuple(properties_raw["regions"])}
+    if "types" in properties_raw and isinstance(properties_raw["types"], list):
+        properties_raw = {**properties_raw, "types": tuple(properties_raw["types"])}
+    if "type_shares" in properties_raw and isinstance(
+        properties_raw["type_shares"], list
+    ):
+        properties_raw = {
+            **properties_raw,
+            "type_shares": tuple(properties_raw["type_shares"]),
+        }
+
+    mortgage_raw = _extract(behavior, "banks", "mortgage")
+
     return ModelConfig(
         simulation=SimulationConfig(**sim_raw),
         firms=FirmConfig(**firms_raw),
@@ -240,11 +316,16 @@ def load_config(path: Path | None = None) -> ModelConfig:
         households=HouseholdConfig(**hh_raw),
         household_behavior=HouseholdBehaviorConfig(**behavior.get("households", {})),
         banks=BankConfig(**banks_raw),
-        bank_behavior=BankBehaviorConfig(**behavior.get("banks", {})),
+        bank_behavior=BankBehaviorConfig(
+            **{k: v for k, v in behavior.get("banks", {}).items() if k != "mortgage"}
+        ),
         taylor_rule=TaylorRuleConfig(**_extract(policy, "central_bank", "taylor_rule")),
         fiscal_rule=FiscalRuleConfig(**_extract(policy, "government", "fiscal_rule")),
         transfers=TransfersConfig(**_extract(policy, "government", "transfers")),
         goods_market=GoodsMarketConfig(**markets.get("goods", {})),
         labor_market=LaborMarketConfig(**markets.get("labor", {})),
         credit_market=CreditMarketConfig(**markets.get("credit", {})),
+        properties=PropertyConfig(**properties_raw),
+        housing_market=HousingMarketConfig(**markets.get("housing", {})),
+        mortgage=MortgageConfig(**mortgage_raw),
     )

--- a/src/companies_house_abm/abm/config.py
+++ b/src/companies_house_abm/abm/config.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 
 import yaml
-
-if TYPE_CHECKING:
-    from typing import Any
 
 _DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config"
 
@@ -287,31 +284,27 @@ def load_config(path: Path | None = None) -> ModelConfig:
     banks_raw = agents.get("banks", {})
 
     # Sectors arrive as a list; convert to tuple for the frozen dataclass
-    if "sectors" in firms_raw and isinstance(firms_raw["sectors"], list):
-        firms_raw = {**firms_raw, "sectors": tuple(firms_raw["sectors"])}
-
-    # Handle size_classes key that's in YAML but not in the dataclass
-    firms_raw = {k: v for k, v in firms_raw.items() if k != "size_classes"}
+    firms_raw_d: dict[str, Any] = dict(firms_raw)
+    if "sectors" in firms_raw_d and isinstance(firms_raw_d["sectors"], list):
+        firms_raw_d["sectors"] = tuple(firms_raw_d["sectors"])
+    firms_raw_d.pop("size_classes", None)
 
     # Housing: properties, housing market, and mortgage config
-    properties_raw = agents.get("properties", {})
-    if "regions" in properties_raw and isinstance(properties_raw["regions"], list):
-        properties_raw = {**properties_raw, "regions": tuple(properties_raw["regions"])}
-    if "types" in properties_raw and isinstance(properties_raw["types"], list):
-        properties_raw = {**properties_raw, "types": tuple(properties_raw["types"])}
-    if "type_shares" in properties_raw and isinstance(
-        properties_raw["type_shares"], list
+    properties_raw_d: dict[str, Any] = dict(agents.get("properties", {}))
+    if "regions" in properties_raw_d and isinstance(properties_raw_d["regions"], list):
+        properties_raw_d["regions"] = tuple(properties_raw_d["regions"])
+    if "types" in properties_raw_d and isinstance(properties_raw_d["types"], list):
+        properties_raw_d["types"] = tuple(properties_raw_d["types"])
+    if "type_shares" in properties_raw_d and isinstance(
+        properties_raw_d["type_shares"], list
     ):
-        properties_raw = {
-            **properties_raw,
-            "type_shares": tuple(properties_raw["type_shares"]),
-        }
+        properties_raw_d["type_shares"] = tuple(properties_raw_d["type_shares"])
 
     mortgage_raw = _extract(behavior, "banks", "mortgage")
 
     return ModelConfig(
         simulation=SimulationConfig(**sim_raw),
-        firms=FirmConfig(**firms_raw),
+        firms=FirmConfig(**firms_raw_d),
         firm_behavior=FirmBehaviorConfig(**behavior.get("firms", {})),
         households=HouseholdConfig(**hh_raw),
         household_behavior=HouseholdBehaviorConfig(**behavior.get("households", {})),
@@ -325,7 +318,7 @@ def load_config(path: Path | None = None) -> ModelConfig:
         goods_market=GoodsMarketConfig(**markets.get("goods", {})),
         labor_market=LaborMarketConfig(**markets.get("labor", {})),
         credit_market=CreditMarketConfig(**markets.get("credit", {})),
-        properties=PropertyConfig(**properties_raw),
+        properties=PropertyConfig(**properties_raw_d),
         housing_market=HousingMarketConfig(**markets.get("housing", {})),
         mortgage=MortgageConfig(**mortgage_raw),
     )

--- a/src/companies_house_abm/abm/markets/__init__.py
+++ b/src/companies_house_abm/abm/markets/__init__.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from companies_house_abm.abm.markets.base import BaseMarket
 from companies_house_abm.abm.markets.credit import CreditMarket
 from companies_house_abm.abm.markets.goods import GoodsMarket
+from companies_house_abm.abm.markets.housing import HousingMarket
 from companies_house_abm.abm.markets.labor import LaborMarket
 
 __all__ = [
     "BaseMarket",
     "CreditMarket",
     "GoodsMarket",
+    "HousingMarket",
     "LaborMarket",
 ]

--- a/src/companies_house_abm/abm/markets/housing.py
+++ b/src/companies_house_abm/abm/markets/housing.py
@@ -1,0 +1,381 @@
+"""Housing market with bilateral matching and aspiration-level pricing.
+
+Implements the market mechanism described by Farmer (2025) and adapted
+for the UK by Baptista et al. (2016) and Carro et al. (2022).  Unlike
+the goods or labour markets, the housing market does **not** clear to
+equilibrium.  Buyers and sellers are matched bilaterally, prices
+adjust sluggishly through aspiration-level adaptation, and persistent
+imbalances between supply and demand are the norm.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from companies_house_abm.abm.markets.base import BaseMarket
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from companies_house_abm.abm.agents.bank import Bank
+    from companies_house_abm.abm.agents.household import Household
+    from companies_house_abm.abm.assets.mortgage import Mortgage
+    from companies_house_abm.abm.assets.property import Property
+    from companies_house_abm.abm.config import HousingMarketConfig
+
+
+class HousingMarket(BaseMarket):
+    """UK housing market with bilateral matching.
+
+    Each period the market:
+    1. Updates asking prices for listed properties (aspiration-level
+       adaptation).
+    2. Collects potential buyers (households that want to buy).
+    3. Matches buyers to listed properties via a search process.
+    4. Processes transactions (mortgage origination, ownership transfer).
+    5. Records aggregate statistics.
+    """
+
+    def __init__(
+        self,
+        config: HousingMarketConfig | None = None,
+    ) -> None:
+        self._config = config
+
+        # Aggregate state
+        self.average_price: float = 285_000.0
+        self.transactions: int = 0
+        self.listings: int = 0
+        self.months_supply: float = 0.0
+        self.price_to_income: float = 0.0
+        self.house_price_inflation: float = 0.0
+        self.total_mortgage_lending: float = 0.0
+        self.foreclosures: int = 0
+        self.homeownership_rate: float = 0.0
+
+        self._previous_average_price: float = 285_000.0
+        self._price_history: list[float] = []
+
+        # References (set via set_agents)
+        self._properties: list[Property] = []
+        self._households: list[Household] = []
+        self._banks: list[Bank] = []
+        self._mortgages: list[Mortgage] = []
+        self._rng: np.random.Generator = np.random.default_rng(42)
+        self._period: int = 0
+
+    def set_agents(
+        self,
+        properties: list[Property],
+        households: list[Household],
+        banks: list[Bank],
+        mortgages: list[Mortgage],
+        rng: np.random.Generator | None = None,
+    ) -> None:
+        """Register agent populations with the market."""
+        self._properties = properties
+        self._households = households
+        self._banks = banks
+        self._mortgages = mortgages
+        if rng is not None:
+            self._rng = rng
+
+    def set_period(self, period: int) -> None:
+        """Update the current period counter."""
+        self._period = period
+
+    # ------------------------------------------------------------------
+    # Market clearing
+    # ------------------------------------------------------------------
+
+    def clear(self) -> dict[str, Any]:
+        """Execute one period of the housing market.
+
+        Returns:
+            Dictionary of aggregate market outcomes.
+        """
+        self._previous_average_price = self.average_price
+
+        # Phase 1: Sellers update asking prices
+        self._update_asking_prices()
+
+        # Phase 2: Collect buyers
+        buyers = [hh for hh in self._households if hh.wants_to_buy and hh.wealth > 0]
+
+        # Phase 3: Collect listings
+        listed = [p for p in self._properties if p.on_market]
+
+        # Phase 4: Bilateral matching
+        period_transactions = 0
+        period_lending = 0.0
+
+        if buyers and listed:
+            period_transactions, period_lending = self._match_buyers_sellers(
+                buyers, listed
+            )
+
+        # Phase 5: Update statistics
+        self._update_statistics(period_transactions, period_lending)
+
+        return self.get_state()
+
+    def _update_asking_prices(self) -> None:
+        """Aspiration-level adaptation: reduce prices of unsold listings."""
+        reduction = self._config.price_reduction_rate if self._config else 0.10
+        max_months = self._config.max_months_listed if self._config else 6
+
+        for prop in self._properties:
+            if not prop.on_market:
+                continue
+            if prop.months_listed >= max_months:
+                prop.delist()
+                # Owner may try again later
+                owner = self._find_household(prop.owner_id)
+                if owner:
+                    owner.wants_to_sell = False
+            else:
+                prop.reduce_price(reduction)
+
+    def _match_buyers_sellers(
+        self,
+        buyers: list[Household],
+        listed: list[Property],
+    ) -> tuple[int, float]:
+        """Bilateral matching: buyers search, bid, transactions clear.
+
+        Returns:
+            (number of transactions, total mortgage lending)
+        """
+        search_intensity = self._config.search_intensity if self._config else 10
+        transactions = 0
+        lending = 0.0
+
+        # Shuffle buyers for fairness
+        buyer_indices = list(range(len(buyers)))
+        self._rng.shuffle(buyer_indices)
+
+        # Track which properties are sold this period
+        sold_ids: set[str] = set()
+
+        for idx in buyer_indices:
+            buyer = buyers[idx]
+            if not buyer.wants_to_buy:
+                continue
+
+            # Budget: wealth (deposit) + max mortgage
+            annual_income = buyer.wage * 12.0 if buyer.employed else 0.0
+            max_dti = 4.5
+            max_mortgage = annual_income * max_dti
+            max_budget = buyer.wealth + max_mortgage
+
+            # Search: sample properties within budget
+            affordable = [
+                p
+                for p in listed
+                if p.property_id not in sold_ids
+                and p.asking_price <= max_budget
+                and p.on_market
+            ]
+            if not affordable:
+                buyer.months_searching += 1
+                continue
+
+            n_visit = min(search_intensity, len(affordable))
+            visited_indices = self._rng.choice(
+                len(affordable), size=n_visit, replace=False
+            )
+            visited = [affordable[i] for i in visited_indices]
+
+            # Pick best value (lowest asking price relative to quality)
+            best = min(visited, key=lambda p: p.asking_price / max(p.quality, 0.01))
+
+            # Attempt to transact
+            result = self._attempt_transaction(buyer, best, annual_income)
+            if result is not None:
+                transactions += 1
+                lending += result
+                sold_ids.add(best.property_id)
+                buyer.wants_to_buy = False
+                buyer.months_searching = 0
+
+        return transactions, lending
+
+    def _attempt_transaction(
+        self,
+        buyer: Household,
+        prop: Property,
+        annual_income: float,
+    ) -> float | None:
+        """Try to complete a purchase.  Returns mortgage amount or None."""
+        sale_price = prop.asking_price
+        deposit = min(buyer.wealth, sale_price)
+        loan_needed = sale_price - deposit
+
+        if loan_needed > 0:
+            # Find a bank willing to lend
+            bank = self._find_lender(annual_income, deposit, sale_price)
+            if bank is None:
+                return None
+
+            mortgage = bank.originate_mortgage(
+                borrower_id=buyer.agent_id,
+                property_id=prop.property_id,
+                loan_amount=loan_needed,
+                property_value=sale_price,
+                annual_income=annual_income,
+                period=self._period,
+            )
+            self._mortgages.append(mortgage)
+            buyer.mortgage = mortgage
+        else:
+            loan_needed = 0.0
+
+        # Transfer ownership
+        old_owner_id = prop.owner_id
+        prop.sell(
+            new_owner_id=buyer.agent_id,
+            sale_price=sale_price,
+            period=self._period,
+        )
+
+        # Update buyer state
+        buyer.wealth -= deposit
+        buyer.tenure = "owner_occupier"
+        buyer.property_id = prop.property_id
+        buyer.rent = 0.0
+        buyer.housing_wealth = sale_price - loan_needed
+
+        # If there was a previous owner, update their state
+        if old_owner_id:
+            seller = self._find_household(old_owner_id)
+            if seller:
+                seller.wealth += sale_price
+                if seller.property_id == prop.property_id:
+                    seller.property_id = None
+                    seller.tenure = "renter"
+                    seller.housing_wealth = 0.0
+                    # Clear seller's mortgage on this property
+                    has_mortgage = (
+                        seller.mortgage
+                        and seller.mortgage.property_id == prop.property_id
+                    )
+                    if has_mortgage:
+                        remaining = seller.mortgage.outstanding
+                        seller.wealth -= remaining  # pay off mortgage
+                        bank_id = seller.mortgage.lender_id
+                        for b in self._banks:
+                            if b.agent_id == bank_id:
+                                b.record_mortgage_repayment(remaining)
+                                break
+                        self._mortgages = [
+                            m
+                            for m in self._mortgages
+                            if m.mortgage_id != seller.mortgage.mortgage_id
+                        ]
+                        seller.mortgage = None
+
+        return loan_needed
+
+    def _find_lender(
+        self,
+        annual_income: float,
+        deposit: float,
+        property_value: float,
+    ) -> Bank | None:
+        """Find a bank willing to approve a mortgage."""
+        # Try banks in random order
+        bank_indices = list(range(len(self._banks)))
+        self._rng.shuffle(bank_indices)
+        for idx in bank_indices:
+            bank = self._banks[idx]
+            if bank.evaluate_mortgage(annual_income, deposit, property_value):
+                return bank
+        return None
+
+    def _find_household(self, agent_id: str | None) -> Household | None:
+        """Look up a household by agent_id."""
+        if agent_id is None:
+            return None
+        for hh in self._households:
+            if hh.agent_id == agent_id:
+                return hh
+        return None
+
+    # ------------------------------------------------------------------
+    # Statistics
+    # ------------------------------------------------------------------
+
+    def _update_statistics(self, transactions: int, lending: float) -> None:
+        """Update aggregate market statistics after clearing."""
+        self.transactions = transactions
+        self.total_mortgage_lending = lending
+
+        # Listings
+        listed = [p for p in self._properties if p.on_market]
+        self.listings = len(listed)
+
+        # Average price from recent transactions
+        if transactions > 0:
+            recent_prices = [
+                p.last_transaction_price
+                for p in self._properties
+                if p.last_transaction_period == self._period
+            ]
+            if recent_prices:
+                self.average_price = sum(recent_prices) / len(recent_prices)
+
+        # Price history for expectations
+        self._price_history.append(self.average_price)
+
+        # House price inflation (monthly)
+        if self._previous_average_price > 0:
+            self.house_price_inflation = (
+                self.average_price / self._previous_average_price - 1.0
+            )
+        else:
+            self.house_price_inflation = 0.0
+
+        # Months of supply
+        if transactions > 0:
+            self.months_supply = self.listings / transactions
+        else:
+            self.months_supply = float(self.listings) if self.listings > 0 else 0.0
+
+        # Homeownership rate
+        if self._households:
+            owners = sum(1 for hh in self._households if hh.tenure == "owner_occupier")
+            self.homeownership_rate = owners / len(self._households)
+
+        # Price to income
+        incomes = [
+            hh.wage * 12.0 for hh in self._households if hh.employed and hh.wage > 0
+        ]
+        if incomes:
+            avg_income = sum(incomes) / len(incomes)
+            if avg_income > 0:
+                self.price_to_income = self.average_price / avg_income
+
+    @property
+    def price_history(self) -> list[float]:
+        """Return the recorded price history."""
+        return list(self._price_history)
+
+    # ------------------------------------------------------------------
+    # State reporting
+    # ------------------------------------------------------------------
+
+    def get_state(self) -> dict[str, Any]:
+        """Return the current state of the housing market."""
+        return {
+            "average_price": self.average_price,
+            "transactions": self.transactions,
+            "listings": self.listings,
+            "months_supply": self.months_supply,
+            "price_to_income": self.price_to_income,
+            "house_price_inflation": self.house_price_inflation,
+            "total_mortgage_lending": self.total_mortgage_lending,
+            "foreclosures": self.foreclosures,
+            "homeownership_rate": self.homeownership_rate,
+        }

--- a/src/companies_house_abm/abm/markets/housing.py
+++ b/src/companies_house_abm/abm/markets/housing.py
@@ -257,11 +257,10 @@ class HousingMarket(BaseMarket):
                     seller.tenure = "renter"
                     seller.housing_wealth = 0.0
                     # Clear seller's mortgage on this property
-                    has_mortgage = (
+                    if (
                         seller.mortgage
                         and seller.mortgage.property_id == prop.property_id
-                    )
-                    if has_mortgage:
+                    ):
                         remaining = seller.mortgage.outstanding
                         seller.wealth -= remaining  # pay off mortgage
                         bank_id = seller.mortgage.lender_id

--- a/src/companies_house_abm/abm/model.py
+++ b/src/companies_house_abm/abm/model.py
@@ -16,9 +16,11 @@ from companies_house_abm.abm.agents.central_bank import CentralBank
 from companies_house_abm.abm.agents.firm import Firm
 from companies_house_abm.abm.agents.government import Government
 from companies_house_abm.abm.agents.household import Household
+from companies_house_abm.abm.assets.property import Property
 from companies_house_abm.abm.config import ModelConfig, load_config
 from companies_house_abm.abm.markets.credit import CreditMarket
 from companies_house_abm.abm.markets.goods import GoodsMarket
+from companies_house_abm.abm.markets.housing import HousingMarket
 from companies_house_abm.abm.markets.labor import LaborMarket
 
 if TYPE_CHECKING:
@@ -41,6 +43,14 @@ class PeriodRecord:
     total_lending: float = 0.0
     firm_bankruptcies: int = 0
     total_employment: int = 0
+    # Housing
+    average_house_price: float = 0.0
+    housing_transactions: int = 0
+    housing_listings: int = 0
+    homeownership_rate: float = 0.0
+    house_price_inflation: float = 0.0
+    total_mortgage_lending: float = 0.0
+    foreclosures: int = 0
 
 
 @dataclass
@@ -65,6 +75,16 @@ class SimulationResult:
     def unemployment_series(self) -> list[float]:
         """Unemployment rate values across all recorded periods."""
         return [r.unemployment_rate for r in self.records]
+
+    @property
+    def house_price_series(self) -> list[float]:
+        """Average house price across all recorded periods."""
+        return [r.average_house_price for r in self.records]
+
+    @property
+    def homeownership_series(self) -> list[float]:
+        """Homeownership rate across all recorded periods."""
+        return [r.homeownership_rate for r in self.records]
 
 
 class Simulation:
@@ -102,10 +122,15 @@ class Simulation:
             transfers=self.config.transfers,
         )
 
+        # Housing assets
+        self.properties: list[Property] = []
+        self.mortgages: list = []  # list[Mortgage]
+
         # Markets
         self.goods_market = GoodsMarket(config=self.config.goods_market)
         self.labor_market = LaborMarket(config=self.config.labor_market)
         self.credit_market = CreditMarket(config=self.config.credit_market)
+        self.housing_market = HousingMarket(config=self.config.housing_market)
 
         self.current_period: int = 0
 
@@ -199,16 +224,23 @@ class Simulation:
                     reserves=capital * 0.1,
                     config=cfg.banks,
                     behavior=cfg.bank_behavior,
+                    mortgage_config=cfg.mortgage,
                 )
             )
 
         # --- Initial employment: assign some households to firms ---
         self._initial_employment()
 
+        # --- Initial housing: create properties and assign tenure ---
+        self._initial_housing()
+
         # --- Wire markets ---
         self.goods_market.set_agents(self.firms, self.households, self.government)
         self.labor_market.set_agents(self.firms, self.households, self._rng)
         self.credit_market.set_agents(self.firms, self.banks)
+        self.housing_market.set_agents(
+            self.properties, self.households, self.banks, self.mortgages, rng=self._rng
+        )
 
     def _initial_employment(self) -> None:
         """Assign households to firms for initial employment."""
@@ -222,6 +254,140 @@ class Simulation:
                 hh_idx += 1
             if hh_idx >= len(self.households):
                 break
+
+    def _initial_housing(self) -> None:
+        """Create the initial housing stock and assign tenure.
+
+        Roughly 64% of households become owner-occupiers (matching the
+        English Housing Survey).  The remaining households are renters.
+        """
+        cfg = self.config.properties
+        n_props = min(cfg.count, len(self.households) * 2)
+
+        # Regional price multipliers (London ~1.8x, North East ~0.5x)
+        region_price = {
+            "london": 1.80,
+            "south_east": 1.30,
+            "east": 1.10,
+            "south_west": 1.00,
+            "west_midlands": 0.80,
+            "east_midlands": 0.78,
+            "north_west": 0.70,
+            "north_east": 0.50,
+            "yorkshire": 0.65,
+            "scotland": 0.60,
+            "wales": 0.60,
+        }
+
+        for i in range(n_props):
+            region = cfg.regions[i % len(cfg.regions)]
+            ptype_idx = self._rng.choice(len(cfg.types), p=cfg.type_shares)
+            ptype = cfg.types[int(ptype_idx)]
+            quality = float(np.clip(self._rng.normal(0.5, 0.15), 0.05, 0.95))
+            multiplier = region_price.get(region, 1.0)
+            base_price = cfg.average_price * multiplier
+            price = float(self._rng.lognormal(np.log(base_price), 0.3))
+            rental_yield = self.config.housing_market.rental_yield
+            monthly_rent = price * rental_yield / 12.0
+
+            self.properties.append(
+                Property(
+                    property_id=f"prop_{i:05d}",
+                    region=region,
+                    property_type=ptype,
+                    quality=quality,
+                    market_value=price,
+                    last_transaction_price=price,
+                    rental_value=monthly_rent,
+                )
+            )
+
+        # Assign ~64% of households as owner-occupiers
+        target_ownership = 0.64
+        n_owners = int(len(self.households) * target_ownership)
+        n_owners = min(n_owners, n_props)
+
+        # Shuffle property indices for random assignment
+        prop_indices = list(range(n_props))
+        self._rng.shuffle(prop_indices)
+
+        for i in range(n_owners):
+            hh = self.households[i]
+            prop = self.properties[prop_indices[i]]
+            prop.owner_id = hh.agent_id
+            hh.tenure = "owner_occupier"
+            hh.property_id = prop.property_id
+            hh.housing_wealth = prop.market_value
+            hh.rent = 0.0
+
+        # Remaining households are renters
+        for i in range(n_owners, len(self.households)):
+            hh = self.households[i]
+            hh.tenure = "renter"
+            # Assign to a random property as tenant
+            if n_props > n_owners:
+                rental_idx = prop_indices[
+                    n_owners + (i - n_owners) % (n_props - n_owners)
+                ]
+                rental_prop = self.properties[rental_idx]
+                rental_prop.is_rented = True
+                rental_prop.tenant_id = hh.agent_id
+                hh.rent = rental_prop.rental_value
+
+        # List vacant (unowned, unrented) properties for sale
+        markup = self.config.housing_market.initial_markup
+        for prop in self.properties:
+            if prop.owner_id is None and not prop.is_rented:
+                prop.list_for_sale(initial_markup=markup)
+
+    def _process_foreclosures(self) -> int:
+        """Banks assess mortgages in arrears and foreclose if needed.
+
+        Returns:
+            Number of foreclosures this period.
+        """
+        count = 0
+        for mortgage in list(self.mortgages):
+            if not mortgage.in_arrears:
+                continue
+            # Find the lending bank
+            bank = None
+            for b in self.banks:
+                if b.agent_id == mortgage.lender_id:
+                    bank = b
+                    break
+            if bank is None:
+                continue
+            if not bank.assess_foreclosure(mortgage):
+                continue
+
+            # Foreclose: bank takes possession, household loses home
+            borrower = None
+            for hh in self.households:
+                if hh.agent_id == mortgage.borrower_id:
+                    borrower = hh
+                    break
+
+            bank.record_mortgage_default(mortgage.outstanding)
+
+            if borrower:
+                borrower.tenure = "renter"
+                borrower.property_id = None
+                borrower.mortgage = None
+                borrower.housing_wealth = 0.0
+
+            # Mark property as available
+            for prop in self.properties:
+                if prop.property_id == mortgage.property_id:
+                    prop.owner_id = None
+                    prop.on_market = False
+                    break
+
+            self.mortgages = [
+                m for m in self.mortgages if m.mortgage_id != mortgage.mortgage_id
+            ]
+            count += 1
+        return count
 
     # ------------------------------------------------------------------
     # Execution
@@ -263,16 +429,20 @@ class Simulation:
 
         1. Government begins period (reset flows).
         2. Central bank sets policy rate.
-        3. Banks update lending rates.
+        3. Banks update lending rates and mortgage rates.
         4. Credit market clears.
         5. Firms step (plan, price, hire/fire, produce, financials).
         6. Labour market clears.
-        7. Households step (income, consume, save).
-        8. Goods market clears.
-        9. Government collects taxes and pays transfers.
-        10. Government ends period (compute deficit/debt).
-        11. Central bank observes inflation and output gap.
-        12. Record aggregate statistics.
+        7. Banks assess foreclosures.
+        8. Households step (income, housing payment, consume, save).
+        9. Households make buy/sell decisions.
+        10. Housing market clears (bilateral matching).
+        11. Government spending.
+        12. Goods market clears.
+        13. Tax collection.
+        14. Government ends period (compute deficit/debt).
+        15. Central bank observes inflation, output gap, house prices.
+        16. Banks step (accounting).
 
         Returns:
             A :class:`PeriodRecord` for this period.
@@ -285,9 +455,10 @@ class Simulation:
         # 2. Central bank sets policy rate
         self.central_bank.step()
 
-        # 3. Banks update lending rates
+        # 3. Banks update lending rates and mortgage rates
         for bank in self.banks:
             bank.set_policy_rate(self.central_bank.policy_rate)
+            bank.set_mortgage_rate(self.central_bank.policy_rate)
 
         # 4. Credit market clears
         self.credit_market.clear()
@@ -299,7 +470,10 @@ class Simulation:
         # 6. Labour market clears
         labor_state = self.labor_market.clear()
 
-        # 7. Households step
+        # 7. Banks assess foreclosures
+        foreclosures = self._process_foreclosures()
+
+        # 8. Households step
         # First set transfer income for unemployed
         avg_wage = labor_state["average_wage"]
         unemployed = [h for h in self.households if not h.employed]
@@ -318,15 +492,42 @@ class Simulation:
         for hh in self.households:
             hh.transfer_income = 0.0
 
-        # 8. Government spending
+        # 9. Households make buy/sell decisions
+        mortgage_rate = self.banks[0].mortgage_rate if self.banks else 0.04
+        rental_yield = self.config.housing_market.rental_yield
+        markup = self.config.housing_market.initial_markup
+        for hh in self.households:
+            hh.decide_buy_or_rent(
+                average_price=self.housing_market.average_price,
+                mortgage_rate=mortgage_rate,
+                rental_yield=rental_yield,
+                price_history=self.housing_market.price_history,
+            )
+            # Owners may decide to sell (~2% per period, or if unemployed)
+            if hh.tenure == "owner_occupier" and hh.property_id:
+                sell_prob = 0.02
+                if not hh.employed:
+                    sell_prob = 0.10  # financial stress
+                if float(self._rng.random()) < sell_prob:
+                    hh.wants_to_sell = True
+                    for prop in self.properties:
+                        if prop.property_id == hh.property_id and not prop.on_market:
+                            prop.list_for_sale(initial_markup=markup)
+                            break
+
+        # 10. Housing market clears
+        self.housing_market.set_period(self.current_period)
+        housing_state = self.housing_market.clear()
+
+        # 11. Government spending
         gdp = sum(f.turnover for f in self.firms if not f.bankrupt)
         self.government.gdp_estimate = gdp
         self.government.calculate_spending()
 
-        # 9. Goods market clears
+        # 12. Goods market clears
         goods_state = self.goods_market.clear()
 
-        # 10. Tax collection
+        # 13. Tax collection
         for firm in self.firms:
             if firm.profit > 0 and not firm.bankrupt:
                 tax = self.government.collect_corporate_tax(firm.profit)
@@ -337,17 +538,17 @@ class Simulation:
                 tax = self.government.collect_income_tax(hh.income)
                 hh.wealth -= tax
 
-        # 11. Government ends period
+        # 14. Government ends period
         self.government.step()
         self.government.end_period()
 
-        # 12. Central bank observes
+        # 15. Central bank observes
         self.central_bank.update_observations(
             inflation=goods_state["inflation"],
             output_gap=0.0,  # simplified: no potential GDP estimation yet
         )
 
-        # 13. Bank step
+        # 16. Bank step
         for bank in self.banks:
             bank.step()
 
@@ -366,4 +567,11 @@ class Simulation:
             total_lending=self.credit_market.total_lending,
             firm_bankruptcies=bankruptcies,
             total_employment=labor_state["total_employed"],
+            average_house_price=housing_state["average_price"],
+            housing_transactions=housing_state["transactions"],
+            housing_listings=housing_state["listings"],
+            homeownership_rate=housing_state["homeownership_rate"],
+            house_price_inflation=housing_state["house_price_inflation"],
+            total_mortgage_lending=housing_state["total_mortgage_lending"],
+            foreclosures=foreclosures,
         )

--- a/src/companies_house_abm/data_sources/__init__.py
+++ b/src/companies_house_abm/data_sources/__init__.py
@@ -30,6 +30,7 @@ from companies_house_abm.data_sources.calibration import (
     calibrate_banks,
     calibrate_government,
     calibrate_households,
+    calibrate_housing,
     calibrate_io_sectors,
     calibrate_model,
 )
@@ -42,6 +43,10 @@ from companies_house_abm.data_sources.hmrc import (
     get_national_insurance_rates,
     get_vat_rate,
 )
+from companies_house_abm.data_sources.land_registry import (
+    fetch_regional_prices,
+    fetch_uk_average_price,
+)
 from companies_house_abm.data_sources.ons import (
     fetch_gdp,
     fetch_household_income,
@@ -49,13 +54,20 @@ from companies_house_abm.data_sources.ons import (
     fetch_labour_market,
     fetch_savings_ratio,
 )
+from companies_house_abm.data_sources.ons_housing import (
+    fetch_affordability_ratio,
+    fetch_rental_growth,
+    fetch_tenure_distribution,
+)
 
 __all__ = [
     "calibrate_banks",
     "calibrate_government",
     "calibrate_households",
+    "calibrate_housing",
     "calibrate_io_sectors",
     "calibrate_model",
+    "fetch_affordability_ratio",
     "fetch_bank_rate",
     "fetch_bank_rate_current",
     "fetch_gdp",
@@ -63,7 +75,11 @@ __all__ = [
     "fetch_input_output_table",
     "fetch_labour_market",
     "fetch_lending_rates",
+    "fetch_regional_prices",
+    "fetch_rental_growth",
     "fetch_savings_ratio",
+    "fetch_tenure_distribution",
+    "fetch_uk_average_price",
     "get_corporation_tax_rate",
     "get_income_tax_bands",
     "get_national_insurance_rates",

--- a/src/companies_house_abm/data_sources/calibration.py
+++ b/src/companies_house_abm/data_sources/calibration.py
@@ -22,7 +22,9 @@ from companies_house_abm.abm.config import (
     BankConfig,
     FiscalRuleConfig,
     HouseholdConfig,
+    HousingMarketConfig,
     ModelConfig,
+    PropertyConfig,
     TransfersConfig,
     load_config,
 )
@@ -305,6 +307,68 @@ def calibrate_io_sectors() -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Housing calibration
+# ---------------------------------------------------------------------------
+
+
+def calibrate_housing(
+    base_properties: PropertyConfig | None = None,
+    base_market: HousingMarketConfig | None = None,
+) -> tuple[PropertyConfig, HousingMarketConfig]:
+    """Calibrate housing parameters from Land Registry and ONS data.
+
+    Sets average house price from UK HPI and rental yield from ONS
+    rental price growth data.
+
+    Args:
+        base_properties: Existing
+            :class:`~companies_house_abm.abm.config.PropertyConfig`.
+        base_market: Existing
+            :class:`~companies_house_abm.abm.config.HousingMarketConfig`.
+
+    Returns:
+        Tuple of updated ``(PropertyConfig, HousingMarketConfig)``.
+    """
+    from companies_house_abm.data_sources.land_registry import (
+        fetch_uk_average_price,
+    )
+    from companies_house_abm.data_sources.ons_housing import (
+        fetch_affordability_ratio,
+        fetch_tenure_distribution,
+    )
+
+    if base_properties is None:
+        base_properties = PropertyConfig()
+    if base_market is None:
+        base_market = HousingMarketConfig()
+
+    prop_overrides: dict[str, Any] = {}
+    market_overrides: dict[str, Any] = {}
+
+    # --- Average price from UK HPI ---
+    avg_price = fetch_uk_average_price()
+    if avg_price > 0:
+        prop_overrides["average_price"] = avg_price
+        logger.info("Calibrated average house price: £%.0f", avg_price)
+
+    # --- Tenure distribution (for validation) ---
+    tenure = fetch_tenure_distribution()
+    logger.info(
+        "Tenure distribution: owners=%.0f%% renters=%.0f%%",
+        tenure.get("owner_occupier", 0) * 100,
+        (tenure.get("private_renter", 0) + tenure.get("social_renter", 0)) * 100,
+    )
+
+    # --- Affordability ratio (for validation) ---
+    affordability = fetch_affordability_ratio()
+    logger.info("Price-to-income affordability ratio: %.1f", affordability)
+
+    return replace(base_properties, **prop_overrides), replace(
+        base_market, **market_overrides
+    )
+
+
+# ---------------------------------------------------------------------------
 # Full model calibration
 # ---------------------------------------------------------------------------
 
@@ -340,6 +404,7 @@ def calibrate_model(base: ModelConfig | None = None) -> ModelConfig:
     households = calibrate_households(base.households)
     bank_config, bank_behavior = calibrate_banks(base.banks, base.bank_behavior)
     fiscal_rule, transfers = calibrate_government(base.fiscal_rule, base.transfers)
+    properties, housing_market = calibrate_housing(base.properties, base.housing_market)
 
     return replace(
         base,
@@ -348,4 +413,6 @@ def calibrate_model(base: ModelConfig | None = None) -> ModelConfig:
         bank_behavior=bank_behavior,
         fiscal_rule=fiscal_rule,
         transfers=transfers,
+        properties=properties,
+        housing_market=housing_market,
     )

--- a/src/companies_house_abm/data_sources/companies_house.py
+++ b/src/companies_house_abm/data_sources/companies_house.py
@@ -186,7 +186,7 @@ def _normalise(raw: pl.DataFrame) -> pl.DataFrame:
         Clean DataFrame with columns ``companies_house_registered_number``
         and ``sic_code``.
     """
-    return (
+    result: pl.DataFrame = (
         raw.lazy()
         .filter(
             pl.col(_COL_COMPANY_NUMBER).is_not_null() & pl.col(_COL_SIC_1).is_not_null()
@@ -206,6 +206,7 @@ def _normalise(raw: pl.DataFrame) -> pl.DataFrame:
         .unique(subset=["companies_house_registered_number"], keep="first")
         .collect()
     )
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/src/companies_house_abm/data_sources/firm_distributions.py
+++ b/src/companies_house_abm/data_sources/firm_distributions.py
@@ -450,20 +450,23 @@ def profile_field(
     if q_low is not None and q_high is not None:
         outlier_count = int(((non_null < q_low) | (non_null > q_high)).sum())
 
+    def _f(v: object) -> float | None:
+        return float(v) if v is not None else None  # type: ignore[arg-type]
+
     return FieldProfile(
         name=series.name,
         count=total,
         null_count=null_count,
         null_pct=null_pct,
-        mean=non_null.mean(),
-        std=non_null.std(),
-        min=non_null.min(),
-        q25=non_null.quantile(0.25, interpolation="linear"),
-        median=non_null.median(),
-        q75=non_null.quantile(0.75, interpolation="linear"),
-        max=non_null.max(),
-        outlier_low=q_low,
-        outlier_high=q_high,
+        mean=_f(non_null.mean()),
+        std=_f(non_null.std()),
+        min=_f(non_null.min()),
+        q25=_f(non_null.quantile(0.25, interpolation="linear")),
+        median=_f(non_null.median()),
+        q75=_f(non_null.quantile(0.75, interpolation="linear")),
+        max=_f(non_null.max()),
+        outlier_low=_f(q_low),
+        outlier_high=_f(q_high),
         outlier_count=outlier_count,
     )
 
@@ -662,7 +665,7 @@ def compute_sector_year_parameters(
             results.append(
                 SectorYearParameters(
                     sector=str(sector),
-                    financial_year=int(fy),  # type: ignore[arg-type]
+                    financial_year=int(fy),
                     n_companies=len(group_df),
                     distributions=distributions,
                 )
@@ -780,10 +783,10 @@ def run_profile_pipeline(
     if sample_fraction is not None:
         logger.info("Sampling %.1f%% of data", sample_fraction * 100)
         # Collect and sample — sampling a lazy frame requires collecting
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
         df = df.sample(fraction=sample_fraction, seed=42)
     else:
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
 
     logger.info("Loaded %d rows for %d companies", len(df), df["company_id"].n_unique())
 

--- a/src/companies_house_abm/data_sources/land_registry.py
+++ b/src/companies_house_abm/data_sources/land_registry.py
@@ -1,0 +1,127 @@
+"""HM Land Registry house price data fetcher.
+
+Provides summary statistics from HM Land Registry Price Paid data and
+the UK House Price Index (UK HPI), available at
+https://landregistry.data.gov.uk/.
+
+Data is Crown Copyright, reproduced under the Open Government Licence.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from companies_house_abm.data_sources._http import retry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# UK HPI Linked Data API
+# ---------------------------------------------------------------------------
+
+_UK_HPI_API = "https://landregistry.data.gov.uk/app/ukhpi"
+
+# SPARQL endpoint for UK HPI
+_SPARQL_ENDPOINT = "https://landregistry.data.gov.uk/landregistry/query"
+
+# Fallback values (2024 Q3, ONS UK HPI)
+_FALLBACK_PRICES: dict[str, float] = {
+    "london": 523_000.0,
+    "south_east": 380_000.0,
+    "east": 320_000.0,
+    "south_west": 305_000.0,
+    "west_midlands": 235_000.0,
+    "east_midlands": 230_000.0,
+    "north_west": 205_000.0,
+    "north_east": 155_000.0,
+    "yorkshire": 195_000.0,
+    "scotland": 185_000.0,
+    "wales": 195_000.0,
+}
+
+_FALLBACK_UK_AVERAGE = 285_000.0
+
+
+def _get_json(url: str) -> Any:
+    """Fetch JSON from the Land Registry API with retry."""
+    from companies_house_abm.data_sources._http import get_json
+
+    return retry(get_json, url)
+
+
+def fetch_regional_prices() -> dict[str, float]:
+    """Fetch average house prices by UK region.
+
+    Attempts to query the UK HPI SPARQL endpoint for the most recent
+    regional average prices.  Falls back to hardcoded 2024 values if
+    the API is unavailable.
+
+    Returns:
+        Dict mapping region name to average price (GBP).
+    """
+    try:
+        query = """
+        PREFIX ukhpi: <http://landregistry.data.gov.uk/def/ukhpi/>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?region ?price WHERE {
+            ?obs ukhpi:refRegion ?regionUri ;
+                 ukhpi:averagePrice ?price ;
+                 ukhpi:refPeriod ?period .
+            ?regionUri rdfs:label ?region .
+        }
+        ORDER BY DESC(?period)
+        LIMIT 20
+        """
+        url = f"{_SPARQL_ENDPOINT}?query={_encode_query(query)}&output=json"
+        data = _get_json(url)
+        results = data.get("results", {}).get("bindings", [])
+        if results:
+            prices: dict[str, float] = {}
+            for row in results:
+                region = row.get("region", {}).get("value", "").lower()
+                price = float(row.get("price", {}).get("value", 0))
+                if region and price > 0 and region not in prices:
+                    prices[region] = price
+            if prices:
+                logger.info("Fetched %d regional prices from UK HPI", len(prices))
+                return prices
+    except Exception:
+        logger.warning("UK HPI API unavailable, using fallback prices")
+
+    return dict(_FALLBACK_PRICES)
+
+
+def fetch_uk_average_price() -> float:
+    """Fetch the current UK average house price.
+
+    Returns:
+        UK average house price in GBP.
+    """
+    prices = fetch_regional_prices()
+    if prices:
+        return sum(prices.values()) / len(prices)
+    return _FALLBACK_UK_AVERAGE
+
+
+def fetch_price_by_type() -> dict[str, float]:
+    """Fetch average prices by property type.
+
+    Returns:
+        Dict mapping property type to average price (GBP).
+        Falls back to approximate 2024 values.
+    """
+    return {
+        "detached": 440_000.0,
+        "semi_detached": 275_000.0,
+        "terraced": 235_000.0,
+        "flat": 225_000.0,
+    }
+
+
+def _encode_query(query: str) -> str:
+    """URL-encode a SPARQL query string."""
+    import urllib.parse
+
+    return urllib.parse.quote(query.strip())

--- a/src/companies_house_abm/data_sources/ons_housing.py
+++ b/src/companies_house_abm/data_sources/ons_housing.py
@@ -1,0 +1,116 @@
+"""ONS housing statistics fetcher.
+
+Provides tenure distribution, affordability ratios, and rental price
+data from ONS datasets for housing market calibration.
+
+Data is Crown Copyright, reproduced under the Open Government Licence.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from companies_house_abm.data_sources._http import retry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ONS API endpoints
+# ---------------------------------------------------------------------------
+
+_ONS_API = "https://api.beta.ons.gov.uk/v1"
+
+# House price to income affordability ratio (ONS dataset)
+_AFFORDABILITY_SERIES = "HP7A"
+
+# Private rental price index
+_RENTAL_INDEX_SERIES = "D7RA"
+
+# Fallback values (English Housing Survey 2023-24)
+_FALLBACK_TENURE = {
+    "owner_occupier": 0.64,
+    "private_renter": 0.19,
+    "social_renter": 0.17,
+}
+
+_FALLBACK_AFFORDABILITY = 8.3  # median price-to-income
+_FALLBACK_RENTAL_GROWTH = 0.065  # annual rental price growth (2024)
+
+
+def _get_json(url: str) -> Any:
+    """Fetch JSON from the ONS API with retry."""
+    from companies_house_abm.data_sources._http import get_json
+
+    return retry(get_json, url)
+
+
+def fetch_tenure_distribution() -> dict[str, float]:
+    """Fetch the UK housing tenure distribution.
+
+    Returns shares for owner-occupiers, private renters, and social
+    renters.  Falls back to English Housing Survey 2023-24 values.
+
+    Returns:
+        Dict mapping tenure type to share (0-1).
+    """
+    # ONS doesn't expose tenure via a simple series endpoint;
+    # use English Housing Survey headline figures.
+    logger.info("Using EHS 2023-24 tenure distribution (fallback)")
+    return dict(_FALLBACK_TENURE)
+
+
+def fetch_affordability_ratio() -> float:
+    """Fetch the median house price to workplace earnings ratio.
+
+    Uses ONS series HP7A (median workplace-based affordability ratio
+    for England and Wales).
+
+    Returns:
+        Median price-to-income ratio.
+    """
+    try:
+        url = f"{_ONS_API}/datasets/housing-affordability/editions/time-series/versions"
+        data = _get_json(url)
+        items = data.get("items", [])
+        if items:
+            latest = items[0]
+            version_url = latest.get("links", {}).get("self", {}).get("href")
+            if version_url:
+                obs_url = f"{version_url}/observations?geography=K04000001&limit=1"
+                obs_data = _get_json(obs_url)
+                observations = obs_data.get("observations", [])
+                if observations:
+                    value = float(observations[0].get("observation", 0))
+                    if value > 0:
+                        logger.info("Fetched affordability ratio: %.1f", value)
+                        return value
+    except Exception:
+        logger.warning("ONS affordability API unavailable, using fallback")
+
+    return _FALLBACK_AFFORDABILITY
+
+
+def fetch_rental_growth() -> float:
+    """Fetch the annual private rental price growth rate.
+
+    Uses the ONS Index of Private Housing Rental Prices.
+
+    Returns:
+        Annual rental price growth as a decimal (e.g. 0.065 for 6.5%).
+    """
+    try:
+        url = f"{_ONS_API}/timeseries/{_RENTAL_INDEX_SERIES}/dataset/mm23/data"
+        data = _get_json(url)
+        months = data.get("months", [])
+        if len(months) >= 13:
+            latest = float(months[-1].get("value", 0))
+            year_ago = float(months[-13].get("value", 0))
+            if year_ago > 0 and latest > 0:
+                growth = (latest / year_ago) - 1.0
+                logger.info("Fetched rental growth: %.1f%%", growth * 100)
+                return growth
+    except Exception:
+        logger.warning("ONS rental index unavailable, using fallback")
+
+    return _FALLBACK_RENTAL_GROWTH

--- a/src/companies_house_abm/ingest.py
+++ b/src/companies_house_abm/ingest.py
@@ -80,7 +80,9 @@ def infer_start_date(parquet_path: Path) -> date | None:
     if not parquet_path.exists():
         return None
     try:
-        result = pl.scan_parquet(parquet_path).select(pl.col("date").max()).collect()
+        result: pl.DataFrame = (
+            pl.scan_parquet(parquet_path).select(pl.col("date").max()).collect()
+        )
         if result.is_empty() or result[0, 0] is None:
             return None
         return result[0, 0]

--- a/src/companies_house_abm/webapp/app.py
+++ b/src/companies_house_abm/webapp/app.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from fastapi import FastAPI
+
+if TYPE_CHECKING:
+    from companies_house_abm.abm.config import ModelConfig
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -121,7 +125,7 @@ def _config_to_params(cfg: object) -> SimulationParams:
     )
 
 
-def _params_to_config(params: SimulationParams) -> object:
+def _params_to_config(params: SimulationParams) -> ModelConfig:
     """Convert a flat :class:`SimulationParams` to a :class:`ModelConfig`."""
     from companies_house_abm.abm.config import (
         BankBehaviorConfig,
@@ -252,7 +256,7 @@ def run_simulation(params: SimulationParams) -> SimulationResponse:
     from companies_house_abm.abm.model import Simulation
 
     config = _params_to_config(params)
-    sim = Simulation(config)  # type: ignore[arg-type]
+    sim = Simulation(config)
     sim.initialize_agents()
     result = sim.run(periods=params.periods)
 

--- a/src/companies_house_abm/webapp/app.py
+++ b/src/companies_house_abm/webapp/app.py
@@ -53,7 +53,9 @@ def run_simulation(params: SimulationParams) -> SimulationResponse:
         FiscalRuleConfig,
         HouseholdBehaviorConfig,
         HouseholdConfig,
+        HousingMarketConfig,
         ModelConfig,
+        MortgageConfig,
         SimulationConfig,
         TaylorRuleConfig,
     )
@@ -90,6 +92,13 @@ def run_simulation(params: SimulationParams) -> SimulationResponse:
             tax_rate_corporate=params.corporate_tax_rate,
             tax_rate_income_base=params.income_tax_rate,
         ),
+        housing_market=HousingMarketConfig(
+            search_intensity=params.search_intensity,
+        ),
+        mortgage=MortgageConfig(
+            max_ltv=params.max_ltv,
+            max_dti=params.max_dti,
+        ),
     )
 
     sim = Simulation(config)
@@ -109,6 +118,13 @@ def run_simulation(params: SimulationParams) -> SimulationResponse:
             total_lending=r.total_lending,
             firm_bankruptcies=r.firm_bankruptcies,
             total_employment=r.total_employment,
+            average_house_price=r.average_house_price,
+            housing_transactions=r.housing_transactions,
+            housing_listings=r.housing_listings,
+            homeownership_rate=r.homeownership_rate,
+            house_price_inflation=r.house_price_inflation,
+            total_mortgage_lending=r.total_mortgage_lending,
+            foreclosures=r.foreclosures,
         )
         for r in result.records
     ]

--- a/src/companies_house_abm/webapp/models.py
+++ b/src/companies_house_abm/webapp/models.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
+from pydantic.dataclasses import dataclass
 
 
-class SimulationParams(BaseModel):
+@dataclass
+class SimulationParams:
     """Parameters configuring a simulation run."""
 
     # ── Simulation ────────────────────────────────────────────────────────────
@@ -202,7 +204,8 @@ class SimulationParams(BaseModel):
     )
 
 
-class PeriodData(BaseModel):
+@dataclass
+class PeriodData:
     """Aggregate statistics for a single period."""
 
     period: int

--- a/src/companies_house_abm/webapp/models.py
+++ b/src/companies_house_abm/webapp/models.py
@@ -68,6 +68,17 @@ class SimulationParams(BaseModel):
         0.20, ge=0.05, le=0.50, description="Base income tax rate"
     )
 
+    # Housing
+    max_ltv: float = Field(
+        0.90, ge=0.50, le=1.0, description="Maximum loan-to-value ratio"
+    )
+    max_dti: float = Field(
+        4.5, ge=2.0, le=7.0, description="Maximum debt-to-income ratio"
+    )
+    search_intensity: int = Field(
+        10, ge=1, le=50, description="Number of properties a buyer visits per period"
+    )
+
 
 class PeriodData(BaseModel):
     """Aggregate statistics for a single period."""
@@ -83,6 +94,14 @@ class PeriodData(BaseModel):
     total_lending: float
     firm_bankruptcies: int
     total_employment: int
+    # Housing
+    average_house_price: float = 0.0
+    housing_transactions: int = 0
+    housing_listings: int = 0
+    homeownership_rate: float = 0.0
+    house_price_inflation: float = 0.0
+    total_mortgage_lending: float = 0.0
+    foreclosures: int = 0
 
 
 class SimulationResponse(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,12 @@ def reset_typer_force_terminal() -> Generator[None]:
     stale cached value.
     """
     ru = sys.modules.get("typer.rich_utils")
-    old = ru.FORCE_TERMINAL if ru is not None else None
+    old = getattr(ru, "FORCE_TERMINAL", None) if ru is not None else None
     if ru is not None:
-        ru.FORCE_TERMINAL = None
+        ru.FORCE_TERMINAL = None  # type: ignore[attr-defined]
     yield
     if ru is not None:
-        ru.FORCE_TERMINAL = old
+        ru.FORCE_TERMINAL = old  # type: ignore[attr-defined]
 
 
 @pytest.fixture

--- a/tests/test_abm_agents.py
+++ b/tests/test_abm_agents.py
@@ -274,6 +274,11 @@ class TestHousehold:
             "employer_id",
             "wage",
             "mpc",
+            "tenure",
+            "property_id",
+            "rent",
+            "housing_wealth",
+            "has_mortgage",
         }
         assert set(state.keys()) == expected_keys
 
@@ -398,6 +403,10 @@ class TestBank:
             "interest_rate",
             "capital_ratio",
             "profit",
+            "mortgage_book",
+            "mortgage_npl",
+            "mortgage_rate",
+            "mortgage_count",
         }
         assert set(state.keys()) == expected_keys
 

--- a/tests/test_abm_agents.py
+++ b/tests/test_abm_agents.py
@@ -289,17 +289,24 @@ class TestHousehold:
 
 
 class TestBank:
-    def _make_bank(self, **kwargs):
-        defaults = {
-            "capital": 1_000_000.0,
-            "reserves": 100_000.0,
-            "loans": 5_000_000.0,
-            "deposits": 4_000_000.0,
-            "config": BankConfig(),
-            "behavior": BankBehaviorConfig(),
-        }
-        defaults.update(kwargs)
-        return Bank(agent_id="b1", **defaults)
+    def _make_bank(
+        self,
+        capital: float = 1_000_000.0,
+        reserves: float = 100_000.0,
+        loans: float = 5_000_000.0,
+        deposits: float = 4_000_000.0,
+        config: BankConfig | None = None,
+        behavior: BankBehaviorConfig | None = None,
+    ) -> Bank:
+        return Bank(
+            agent_id="b1",
+            capital=capital,
+            reserves=reserves,
+            loans=loans,
+            deposits=deposits,
+            config=config if config is not None else BankConfig(),
+            behavior=behavior if behavior is not None else BankBehaviorConfig(),
+        )
 
     def test_init_defaults(self):
         bank = Bank()

--- a/tests/test_abm_config.py
+++ b/tests/test_abm_config.py
@@ -19,8 +19,11 @@ from companies_house_abm.abm.config import (
     GoodsMarketConfig,
     HouseholdBehaviorConfig,
     HouseholdConfig,
+    HousingMarketConfig,
     LaborMarketConfig,
     ModelConfig,
+    MortgageConfig,
+    PropertyConfig,
     SimulationConfig,
     TaylorRuleConfig,
     TransfersConfig,
@@ -95,10 +98,34 @@ class TestDefaults:
         cfg = CreditMarketConfig()
         assert cfg.rationing is True
 
+    def test_property_config_defaults(self):
+        cfg = PropertyConfig()
+        assert cfg.count == 12_000
+        assert cfg.average_price == 285_000.0
+        assert len(cfg.regions) == 11
+        assert len(cfg.types) == 4
+        assert len(cfg.type_shares) == 4
+
+    def test_housing_market_config_defaults(self):
+        cfg = HousingMarketConfig()
+        assert cfg.search_intensity == 10
+        assert cfg.initial_markup == 0.05
+        assert cfg.backward_expectation_weight == 0.65
+
+    def test_mortgage_config_defaults(self):
+        cfg = MortgageConfig()
+        assert cfg.max_ltv == 0.90
+        assert cfg.max_dti == 4.5
+        assert cfg.default_term_months == 300
+        assert cfg.mortgage_risk_weight == 0.35
+
     def test_model_config_defaults(self):
         cfg = ModelConfig()
         assert cfg.simulation.periods == 400
         assert cfg.firms.sample_size == 50_000
+        assert cfg.properties.count == 12_000
+        assert cfg.housing_market.search_intensity == 10
+        assert cfg.mortgage.max_ltv == 0.90
 
 
 # ---------------------------------------------------------------------------
@@ -150,3 +177,28 @@ class TestLoadConfig:
     def test_sectors_converted_to_tuple(self):
         cfg = load_config()
         assert isinstance(cfg.firms.sectors, tuple)
+
+    def test_load_housing_config(self):
+        cfg = load_config()
+        assert cfg.properties.count == 12_000
+        assert isinstance(cfg.properties.regions, tuple)
+        assert isinstance(cfg.properties.types, tuple)
+        assert isinstance(cfg.properties.type_shares, tuple)
+        assert cfg.housing_market.search_intensity == 10
+        assert cfg.mortgage.max_ltv == 0.90
+
+    def test_load_custom_housing_config(self, tmp_path: Path):
+        custom = {
+            "agents": {"properties": {"count": 5000, "average_price": 300000}},
+            "markets": {"housing": {"search_intensity": 20}},
+            "behavior": {"banks": {"mortgage": {"max_ltv": 0.85}}},
+        }
+        config_path = tmp_path / "housing_config.yml"
+        with config_path.open("w") as fh:
+            yaml.dump(custom, fh)
+
+        cfg = load_config(config_path)
+        assert cfg.properties.count == 5000
+        assert cfg.properties.average_price == 300_000.0
+        assert cfg.housing_market.search_intensity == 20
+        assert cfg.mortgage.max_ltv == 0.85

--- a/tests/test_abm_model.py
+++ b/tests/test_abm_model.py
@@ -23,6 +23,9 @@ class TestPeriodRecord:
         assert rec.period == 0
         assert rec.gdp == 0.0
         assert rec.inflation == 0.0
+        assert rec.average_house_price == 0.0
+        assert rec.housing_transactions == 0
+        assert rec.homeownership_rate == 0.0
 
     def test_custom_values(self):
         rec = PeriodRecord(period=5, gdp=1_000_000.0, inflation=0.02)
@@ -163,3 +166,58 @@ class TestSimulationStep:
         result = sim.run(periods=5)
         for rec in result.records:
             assert rec.gdp >= 0
+
+
+# ---------------------------------------------------------------------------
+# Housing integration
+# ---------------------------------------------------------------------------
+
+
+class TestHousingIntegration:
+    def _make_sim(self) -> Simulation:
+        cfg = ModelConfig(simulation=SimulationConfig(periods=5, seed=42))
+        sim = Simulation(cfg)
+        sim.initialize_agents()
+        # Trim for speed
+        sim.firms = sim.firms[:10]
+        sim.households = sim.households[:50]
+        sim.properties = sim.properties[:100]
+        # Re-wire markets with trimmed populations
+        sim.goods_market.set_agents(sim.firms, sim.households, sim.government)
+        sim.labor_market.set_agents(sim.firms, sim.households, sim._rng)
+        sim.credit_market.set_agents(sim.firms, sim.banks)
+        sim.housing_market.set_agents(
+            sim.properties, sim.households, sim.banks, sim.mortgages, rng=sim._rng
+        )
+        return sim
+
+    def test_properties_created(self):
+        sim = Simulation.from_config()
+        assert len(sim.properties) > 0
+
+    def test_initial_tenure_assignment(self):
+        sim = Simulation.from_config()
+        owners = [hh for hh in sim.households if hh.tenure == "owner_occupier"]
+        renters = [hh for hh in sim.households if hh.tenure == "renter"]
+        total = len(owners) + len(renters)
+        assert total == len(sim.households)
+        # Ownership rate should be approximately 64%
+        rate = len(owners) / len(sim.households)
+        assert 0.5 < rate < 0.8
+
+    def test_step_returns_housing_stats(self):
+        sim = self._make_sim()
+        record = sim.step()
+        assert record.average_house_price > 0
+        assert record.homeownership_rate >= 0
+
+    def test_run_with_housing(self):
+        sim = self._make_sim()
+        result = sim.run(periods=3)
+        assert len(result.house_price_series) == 3
+        assert all(p > 0 for p in result.house_price_series)
+
+    def test_banks_have_mortgage_config(self):
+        sim = Simulation.from_config()
+        for bank in sim.banks:
+            assert bank._mortgage_config is not None

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -704,6 +704,14 @@ class TestCalibrateModel:
                 "companies_house_abm.data_sources.boe.fetch_bank_rate",
                 return_value=[],
             ),
+            patch(
+                "companies_house_abm.data_sources.land_registry.retry",
+                side_effect=Exception("api down"),
+            ),
+            patch(
+                "companies_house_abm.data_sources.ons_housing.retry",
+                side_effect=Exception("api down"),
+            ),
         ):
             from companies_house_abm.data_sources.calibration import calibrate_model
 
@@ -728,6 +736,14 @@ class TestCalibrateModel:
             patch(
                 "companies_house_abm.data_sources.boe.fetch_bank_rate",
                 return_value=[],
+            ),
+            patch(
+                "companies_house_abm.data_sources.land_registry.retry",
+                side_effect=Exception("api down"),
+            ),
+            patch(
+                "companies_house_abm.data_sources.ons_housing.retry",
+                side_effect=Exception("api down"),
             ),
         ):
             from companies_house_abm.data_sources.calibration import calibrate_model

--- a/tests/test_firm_distributions.py
+++ b/tests/test_firm_distributions.py
@@ -158,9 +158,17 @@ def _make_accounts_df(
     return pl.DataFrame(rows, schema_overrides=schema_overrides)
 
 
-def _write_test_parquet(path: Path, n: int = 200, **kwargs: object) -> Path:
+def _write_test_parquet(
+    path: Path,
+    n: int = 200,
+    *,
+    include_dormant: bool = False,
+    include_errors: bool = False,
+) -> Path:
     """Write a synthetic accounts parquet file for testing."""
-    df = _make_accounts_df(n, **kwargs)
+    df = _make_accounts_df(
+        n, include_dormant=include_dormant, include_errors=include_errors
+    )
     path.parent.mkdir(parents=True, exist_ok=True)
     df.write_parquet(path)
     return path
@@ -373,7 +381,7 @@ class TestLoadAccounts:
 
     def test_loads_parquet(self, parquet_path: Path) -> None:
         lf = load_accounts(parquet_path)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
         assert len(df) > 0
         assert "financial_year" in df.columns
         assert "debt_total" in df.columns
@@ -381,21 +389,24 @@ class TestLoadAccounts:
     def test_drops_dormant_by_default(self, parquet_with_dormant: Path) -> None:
         lf_default = load_accounts(parquet_with_dormant)
         lf_keep = load_accounts(parquet_with_dormant, drop_dormant=False)
-        assert lf_default.collect().height <= lf_keep.collect().height
+        df_default: pl.DataFrame = lf_default.collect()
+        df_keep: pl.DataFrame = lf_keep.collect()
+        assert df_default.height <= df_keep.height
 
     def test_drops_errors_by_default(self, parquet_with_dormant: Path) -> None:
         lf_default = load_accounts(parquet_with_dormant)
         lf_keep = load_accounts(parquet_with_dormant, drop_errors=False)
-        assert lf_default.collect().height <= lf_keep.collect().height
+        df_default: pl.DataFrame = lf_default.collect()
+        df_keep: pl.DataFrame = lf_keep.collect()
+        assert df_default.height <= df_keep.height
 
     def test_financial_year_column_added(self, parquet_path: Path) -> None:
-        df = load_accounts(parquet_path).collect()
+        df: pl.DataFrame = load_accounts(parquet_path).collect()
         assert "financial_year" in df.columns
         assert df["financial_year"].dtype == pl.Int32
 
     def test_debt_total_column_added(self, parquet_path: Path) -> None:
-        df = load_accounts(parquet_path).collect()
-        assert "debt_total" in df.columns
+        df: pl.DataFrame = load_accounts(parquet_path).collect()
         # Debt should be non-negative where both creditor columns are non-null
         non_null_debt = df.filter(pl.col("debt_total").is_not_null())["debt_total"]
         assert (non_null_debt >= 0).all()
@@ -427,14 +438,14 @@ class TestAssignSectors:
     def test_no_sic_file_assigns_other_services(self, parquet_path: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=None)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
         assert "sector" in df.columns
         assert df["sector"].unique().to_list() == ["other_services"]
 
     def test_csv_sic_file(self, parquet_path: Path, sic_csv: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=sic_csv)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
         assert "sector" in df.columns
         sectors = df["sector"].unique().to_list()
         assert len(sectors) >= 1
@@ -442,7 +453,7 @@ class TestAssignSectors:
     def test_parquet_sic_file(self, parquet_path: Path, sic_parquet: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=sic_parquet)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
         assert "sector" in df.columns
 
     def test_nonexistent_sic_file_falls_back(self, parquet_path: Path) -> None:
@@ -506,7 +517,7 @@ class TestProfileField:
         assert p.outlier_count > 0
         assert p.outlier_low is not None
         assert p.outlier_high is not None
-        assert p.outlier_low < p.outlier_high  # type: ignore[operator]
+        assert p.outlier_low < p.outlier_high
 
     def test_single_value(self) -> None:
         series = pl.Series("single", [42.0])
@@ -519,7 +530,7 @@ class TestProfileAccounts:
     """Tests for full dataset profiling."""
 
     def test_profile_returns_dataprofile(self, parquet_path: Path) -> None:
-        df = load_accounts(parquet_path).collect()
+        df: pl.DataFrame = load_accounts(parquet_path).collect()
         df = df.with_columns(pl.lit("other_services").alias("sector"))
         profile = profile_accounts(df)
         assert isinstance(profile, DataProfile)
@@ -527,7 +538,7 @@ class TestProfileAccounts:
         assert profile.total_companies > 0
 
     def test_profile_has_field_profiles(self, parquet_path: Path) -> None:
-        df = load_accounts(parquet_path).collect()
+        df: pl.DataFrame = load_accounts(parquet_path).collect()
         df = df.with_columns(pl.lit("other_services").alias("sector"))
         profile = profile_accounts(df)
         assert len(profile.fields) > 0
@@ -537,7 +548,7 @@ class TestProfileAccounts:
             assert col in field_names
 
     def test_date_range(self, parquet_path: Path) -> None:
-        df = load_accounts(parquet_path).collect()
+        df: pl.DataFrame = load_accounts(parquet_path).collect()
         profile = profile_accounts(df)
         assert profile.date_range[0] != "N/A"
         assert profile.date_range[1] != "N/A"
@@ -661,7 +672,7 @@ class TestComputeSectorYearParameters:
     def test_returns_sector_year_parameters(self, parquet_path: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=None)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
 
         results = compute_sector_year_parameters(df)
         assert isinstance(results, list)
@@ -671,7 +682,7 @@ class TestComputeSectorYearParameters:
     def test_parameters_have_distributions(self, parquet_path: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=None)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
 
         results = compute_sector_year_parameters(df)
         for r in results:
@@ -684,7 +695,7 @@ class TestComputeSectorYearParameters:
     def test_results_sorted(self, parquet_path: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=None)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
 
         results = compute_sector_year_parameters(df)
         keys = [(r.sector, r.financial_year) for r in results]
@@ -693,7 +704,7 @@ class TestComputeSectorYearParameters:
     def test_custom_candidates(self, parquet_path: Path) -> None:
         lf = load_accounts(parquet_path)
         lf = assign_sectors(lf, sic_path=None)
-        df = lf.collect()
+        df: pl.DataFrame = lf.collect()
 
         results = compute_sector_year_parameters(df, candidates=("norm", "lognorm"))
         for r in results:

--- a/tests/test_housing_assets.py
+++ b/tests/test_housing_assets.py
@@ -1,0 +1,151 @@
+"""Tests for housing asset dataclasses (Property and Mortgage)."""
+
+from __future__ import annotations
+
+from companies_house_abm.abm.assets.mortgage import Mortgage
+from companies_house_abm.abm.assets.property import Property
+
+
+class TestProperty:
+    def test_default_property(self):
+        p = Property()
+        assert p.region == "south_east"
+        assert p.property_type == "terraced"
+        assert p.market_value == 285_000.0
+        assert p.on_market is False
+        assert p.owner_id is None
+
+    def test_property_id_auto_generated(self):
+        p1 = Property()
+        p2 = Property()
+        assert p1.property_id != p2.property_id
+
+    def test_list_for_sale(self):
+        p = Property(market_value=200_000.0)
+        p.list_for_sale(initial_markup=0.05)
+        assert p.on_market is True
+        assert p.asking_price == 210_000.0
+        assert p.months_listed == 0
+
+    def test_reduce_price(self):
+        p = Property(market_value=200_000.0)
+        p.list_for_sale(initial_markup=0.05)
+        assert p.asking_price == 210_000.0
+        p.reduce_price(reduction_rate=0.10)
+        assert p.asking_price == 189_000.0
+        assert p.months_listed == 1
+
+    def test_delist(self):
+        p = Property()
+        p.list_for_sale()
+        p.delist()
+        assert p.on_market is False
+        assert p.asking_price == 0.0
+        assert p.months_listed == 0
+
+    def test_sell(self):
+        p = Property(market_value=200_000.0, owner_id="seller_1")
+        p.list_for_sale()
+        p.sell(new_owner_id="buyer_1", sale_price=195_000.0, period=10)
+        assert p.owner_id == "buyer_1"
+        assert p.last_transaction_price == 195_000.0
+        assert p.last_transaction_period == 10
+        assert p.market_value == 195_000.0
+        assert p.on_market is False
+
+    def test_sell_clears_rental(self):
+        p = Property(is_rented=True, tenant_id="tenant_1")
+        p.sell(new_owner_id="buyer_1", sale_price=200_000.0, period=5)
+        assert p.is_rented is False
+        assert p.tenant_id is None
+
+    def test_get_state(self):
+        p = Property(region="london", property_type="flat")
+        state = p.get_state()
+        assert state["region"] == "london"
+        assert state["property_type"] == "flat"
+        assert "property_id" in state
+        assert "market_value" in state
+
+
+class TestMortgage:
+    def test_default_mortgage(self):
+        m = Mortgage()
+        assert m.rate_type == "fixed"
+        assert m.term_months == 300
+        assert m.in_arrears is False
+
+    def test_monthly_payment_calculated(self):
+        m = Mortgage(principal=200_000.0, interest_rate=0.04, term_months=300)
+        # Annuity payment for 200k at 4% over 25 years should be ~1,055
+        assert 1050.0 < m.monthly_payment < 1060.0
+
+    def test_monthly_payment_zero_rate(self):
+        m = Mortgage(principal=120_000.0, interest_rate=0.0, term_months=300)
+        assert m.monthly_payment == 400.0
+
+    def test_current_ltv(self):
+        m = Mortgage(outstanding=180_000.0)
+        assert m.current_ltv(200_000.0) == 0.9
+
+    def test_current_ltv_zero_value(self):
+        m = Mortgage(outstanding=100_000.0)
+        assert m.current_ltv(0.0) == float("inf")
+
+    def test_amortize(self):
+        m = Mortgage(
+            principal=200_000.0,
+            outstanding=200_000.0,
+            interest_rate=0.04,
+            term_months=300,
+            remaining_months=300,
+        )
+        payment = m.amortize()
+        assert payment == m.monthly_payment
+        assert m.outstanding < 200_000.0
+        assert m.remaining_months == 299
+
+    def test_amortize_reduces_balance(self):
+        m = Mortgage(
+            principal=200_000.0,
+            outstanding=200_000.0,
+            interest_rate=0.04,
+            term_months=300,
+            remaining_months=300,
+        )
+        initial = m.outstanding
+        m.amortize()
+        # After one payment, outstanding should be less by principal portion
+        monthly_rate = 0.04 / 12.0
+        interest = initial * monthly_rate
+        expected_outstanding = initial - (m.monthly_payment - interest)
+        assert abs(m.outstanding - expected_outstanding) < 0.01
+
+    def test_record_missed_payment(self):
+        m = Mortgage()
+        m.record_missed_payment()
+        assert m.in_arrears is True
+        assert m.arrears_months == 1
+        m.record_missed_payment()
+        assert m.arrears_months == 2
+
+    def test_record_payment_resets_arrears(self):
+        m = Mortgage()
+        m.record_missed_payment()
+        m.record_missed_payment()
+        m.record_payment_made()
+        assert m.in_arrears is False
+        assert m.arrears_months == 0
+
+    def test_get_state(self):
+        m = Mortgage(borrower_id="hh_1", lender_id="bank_1")
+        state = m.get_state()
+        assert state["borrower_id"] == "hh_1"
+        assert state["lender_id"] == "bank_1"
+        assert "outstanding" in state
+        assert "in_arrears" in state
+
+    def test_mortgage_id_auto_generated(self):
+        m1 = Mortgage()
+        m2 = Mortgage()
+        assert m1.mortgage_id != m2.mortgage_id

--- a/tests/test_housing_data_sources.py
+++ b/tests/test_housing_data_sources.py
@@ -1,0 +1,154 @@
+"""Tests for housing data sources (Land Registry, ONS housing, calibration).
+
+Network calls are mocked so tests run offline and deterministically.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Land Registry
+# ---------------------------------------------------------------------------
+
+
+class TestLandRegistryFallback:
+    def test_regional_prices_fallback(self):
+        from companies_house_abm.data_sources.land_registry import (
+            fetch_regional_prices,
+        )
+
+        with patch(
+            "companies_house_abm.data_sources.land_registry._get_json",
+            side_effect=Exception("offline"),
+        ):
+            prices = fetch_regional_prices()
+        assert "london" in prices
+        assert prices["london"] > prices["north_east"]
+        assert len(prices) == 11
+
+    def test_uk_average_price_fallback(self):
+        from companies_house_abm.data_sources.land_registry import (
+            fetch_uk_average_price,
+        )
+
+        with patch(
+            "companies_house_abm.data_sources.land_registry._get_json",
+            side_effect=Exception("offline"),
+        ):
+            price = fetch_uk_average_price()
+        assert price > 0
+
+    def test_price_by_type(self):
+        from companies_house_abm.data_sources.land_registry import (
+            fetch_price_by_type,
+        )
+
+        prices = fetch_price_by_type()
+        assert "detached" in prices
+        assert "flat" in prices
+        assert prices["detached"] > prices["flat"]
+
+
+# ---------------------------------------------------------------------------
+# ONS Housing
+# ---------------------------------------------------------------------------
+
+
+class TestOnsHousing:
+    def test_tenure_distribution_fallback(self):
+        from companies_house_abm.data_sources.ons_housing import (
+            fetch_tenure_distribution,
+        )
+
+        tenure = fetch_tenure_distribution()
+        assert "owner_occupier" in tenure
+        assert tenure["owner_occupier"] == pytest.approx(0.64)
+        total = sum(tenure.values())
+        assert total == pytest.approx(1.0)
+
+    def test_affordability_ratio_fallback(self):
+        from companies_house_abm.data_sources.ons_housing import (
+            fetch_affordability_ratio,
+        )
+
+        with patch(
+            "companies_house_abm.data_sources.ons_housing._get_json",
+            side_effect=Exception("offline"),
+        ):
+            ratio = fetch_affordability_ratio()
+        assert ratio == pytest.approx(8.3)
+
+    def test_rental_growth_fallback(self):
+        from companies_house_abm.data_sources.ons_housing import (
+            fetch_rental_growth,
+        )
+
+        with patch(
+            "companies_house_abm.data_sources.ons_housing._get_json",
+            side_effect=Exception("offline"),
+        ):
+            growth = fetch_rental_growth()
+        assert growth == pytest.approx(0.065)
+
+
+# ---------------------------------------------------------------------------
+# Housing calibration
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrateHousing:
+    def test_calibrate_housing_returns_configs(self):
+        from companies_house_abm.abm.config import (
+            HousingMarketConfig,
+            PropertyConfig,
+        )
+        from companies_house_abm.data_sources.calibration import calibrate_housing
+
+        with (
+            patch(
+                "companies_house_abm.data_sources.land_registry._get_json",
+                side_effect=Exception("offline"),
+            ),
+            patch(
+                "companies_house_abm.data_sources.ons_housing._get_json",
+                side_effect=Exception("offline"),
+            ),
+        ):
+            props, market = calibrate_housing()
+        assert isinstance(props, PropertyConfig)
+        assert isinstance(market, HousingMarketConfig)
+        assert props.average_price > 0
+
+    def test_calibrate_model_includes_housing(self):
+        from companies_house_abm.data_sources import _http
+        from companies_house_abm.data_sources.calibration import calibrate_model
+
+        _http.clear_cache()
+        with (
+            patch(
+                "companies_house_abm.data_sources.ons.retry",
+                side_effect=Exception("api down"),
+            ),
+            patch(
+                "companies_house_abm.data_sources.boe.retry",
+                side_effect=Exception("api down"),
+            ),
+            patch(
+                "companies_house_abm.data_sources.boe.fetch_bank_rate",
+                return_value=[],
+            ),
+            patch(
+                "companies_house_abm.data_sources.land_registry.retry",
+                side_effect=Exception("api down"),
+            ),
+            patch(
+                "companies_house_abm.data_sources.ons_housing.retry",
+                side_effect=Exception("api down"),
+            ),
+        ):
+            cfg = calibrate_model()
+        assert cfg.properties.average_price > 0
+        assert cfg.housing_market.search_intensity > 0

--- a/tests/test_housing_market.py
+++ b/tests/test_housing_market.py
@@ -15,17 +15,24 @@ from companies_house_abm.abm.config import (
 from companies_house_abm.abm.markets.housing import HousingMarket
 
 
-def _make_bank(**overrides):
-    defaults = {
-        "capital": 10_000_000.0,
-        "reserves": 1_000_000.0,
-        "loans": 50_000_000.0,
-        "deposits": 60_000_000.0,
-        "config": BankConfig(),
-        "mortgage_config": MortgageConfig(),
-    }
-    defaults.update(overrides)
-    bank = Bank(**defaults)
+def _make_bank(
+    capital: float = 10_000_000.0,
+    reserves: float = 1_000_000.0,
+    loans: float = 50_000_000.0,
+    deposits: float = 60_000_000.0,
+    config: BankConfig | None = None,
+    mortgage_config: MortgageConfig | None = None,
+) -> Bank:
+    bank = Bank(
+        capital=capital,
+        reserves=reserves,
+        loans=loans,
+        deposits=deposits,
+        config=config if config is not None else BankConfig(),
+        mortgage_config=(
+            mortgage_config if mortgage_config is not None else MortgageConfig()
+        ),
+    )
     bank.mortgage_rate = 0.04
     return bank
 
@@ -48,15 +55,18 @@ def _make_owner(property_id="p1", wealth=20_000.0, wage=3_000.0):
     return hh
 
 
-def _make_listed_property(price=200_000.0, **overrides):
-    defaults = {
-        "market_value": price,
-        "on_market": True,
-        "asking_price": price * 1.05,
-        "quality": 0.5,
-    }
-    defaults.update(overrides)
-    return Property(**defaults)
+def _make_listed_property(
+    price: float = 200_000.0,
+    quality: float = 0.5,
+    owner_id: str | None = None,
+) -> Property:
+    return Property(
+        market_value=price,
+        on_market=True,
+        asking_price=price * 1.05,
+        quality=quality,
+        owner_id=owner_id,
+    )
 
 
 class TestHousingMarketBasics:

--- a/tests/test_housing_market.py
+++ b/tests/test_housing_market.py
@@ -1,0 +1,194 @@
+"""Tests for the housing market mechanism."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from companies_house_abm.abm.agents.bank import Bank
+from companies_house_abm.abm.agents.household import Household
+from companies_house_abm.abm.assets.property import Property
+from companies_house_abm.abm.config import (
+    BankConfig,
+    HousingMarketConfig,
+    MortgageConfig,
+)
+from companies_house_abm.abm.markets.housing import HousingMarket
+
+
+def _make_bank(**overrides):
+    defaults = {
+        "capital": 10_000_000.0,
+        "reserves": 1_000_000.0,
+        "loans": 50_000_000.0,
+        "deposits": 60_000_000.0,
+        "config": BankConfig(),
+        "mortgage_config": MortgageConfig(),
+    }
+    defaults.update(overrides)
+    bank = Bank(**defaults)
+    bank.mortgage_rate = 0.04
+    return bank
+
+
+def _make_buyer(wealth=50_000.0, wage=3_000.0, employed=True):
+    hh = Household(income=wage, wealth=wealth, mpc=0.8)
+    hh.employed = employed
+    hh.wage = wage
+    hh.tenure = "renter"
+    hh.wants_to_buy = True
+    return hh
+
+
+def _make_owner(property_id="p1", wealth=20_000.0, wage=3_000.0):
+    hh = Household(income=wage, wealth=wealth)
+    hh.employed = True
+    hh.wage = wage
+    hh.tenure = "owner_occupier"
+    hh.property_id = property_id
+    return hh
+
+
+def _make_listed_property(price=200_000.0, **overrides):
+    defaults = {
+        "market_value": price,
+        "on_market": True,
+        "asking_price": price * 1.05,
+        "quality": 0.5,
+    }
+    defaults.update(overrides)
+    return Property(**defaults)
+
+
+class TestHousingMarketBasics:
+    def test_default_state(self):
+        hm = HousingMarket()
+        state = hm.get_state()
+        assert "average_price" in state
+        assert "transactions" in state
+        assert "homeownership_rate" in state
+
+    def test_set_agents(self):
+        hm = HousingMarket()
+        hm.set_agents([], [], [], [])
+        assert hm._properties == []
+
+    def test_clear_empty_market(self):
+        hm = HousingMarket()
+        hm.set_agents([], [], [], [])
+        result = hm.clear()
+        assert result["transactions"] == 0
+
+    def test_clear_no_buyers(self):
+        hm = HousingMarket()
+        props = [_make_listed_property()]
+        hh = Household()  # renter but doesn't want to buy
+        hm.set_agents(props, [hh], [_make_bank()], [])
+        result = hm.clear()
+        assert result["transactions"] == 0
+
+
+class TestAspirationLevelPricing:
+    def test_price_reduces_each_period(self):
+        hm = HousingMarket(config=HousingMarketConfig(price_reduction_rate=0.10))
+        prop = _make_listed_property(price=200_000.0)
+        prop.months_listed = 1  # already been listed 1 month
+        hm.set_agents([prop], [], [], [])
+        hm.clear()
+        # After clearing, price should have been reduced
+        assert prop.asking_price < 200_000.0 * 1.05
+
+    def test_delist_after_max_months(self):
+        hm = HousingMarket(config=HousingMarketConfig(max_months_listed=3))
+        prop = _make_listed_property()
+        prop.months_listed = 3  # at the threshold
+        owner = _make_owner(property_id=prop.property_id)
+        owner.wants_to_sell = True
+        hm.set_agents([prop], [owner], [], [])
+        hm.clear()
+        assert prop.on_market is False
+
+
+class TestBilateralMatching:
+    def test_successful_transaction(self):
+        hm = HousingMarket(config=HousingMarketConfig())
+        rng = np.random.default_rng(42)
+
+        bank = _make_bank()
+        buyer = _make_buyer(wealth=50_000.0, wage=4_000.0)
+        prop = _make_listed_property(price=200_000.0)
+        prop.owner_id = "seller_1"
+        seller = _make_owner(property_id=prop.property_id, wealth=100_000.0)
+        seller.agent_id = "seller_1"
+        seller.wants_to_sell = True
+
+        hm.set_agents([prop], [buyer, seller], [bank], [], rng=rng)
+        hm.set_period(1)
+        result = hm.clear()
+
+        assert result["transactions"] >= 0  # may or may not match
+
+    def test_buyer_cannot_afford(self):
+        hm = HousingMarket(config=HousingMarketConfig())
+        rng = np.random.default_rng(42)
+
+        bank = _make_bank()
+        # Very poor buyer
+        buyer = _make_buyer(wealth=100.0, wage=500.0)
+        prop = _make_listed_property(price=500_000.0)
+
+        hm.set_agents([prop], [buyer], [bank], [], rng=rng)
+        hm.set_period(1)
+        result = hm.clear()
+
+        assert result["transactions"] == 0
+
+    def test_mortgage_denied(self):
+        """Bank rejects mortgage when LTV too high."""
+        hm = HousingMarket(config=HousingMarketConfig())
+        rng = np.random.default_rng(42)
+
+        # Very strict bank
+        bank = _make_bank(mortgage_config=MortgageConfig(max_ltv=0.50))
+        # Buyer with small deposit relative to price
+        buyer = _make_buyer(wealth=10_000.0, wage=4_000.0)
+        prop = _make_listed_property(price=200_000.0)
+
+        hm.set_agents([prop], [buyer], [bank], [], rng=rng)
+        hm.set_period(1)
+        result = hm.clear()
+
+        assert result["transactions"] == 0
+
+
+class TestStatistics:
+    def test_homeownership_rate(self):
+        hm = HousingMarket()
+        owner = _make_owner()
+        renter = Household()
+        renter.tenure = "renter"
+        hm.set_agents([], [owner, renter], [], [])
+        hm.clear()
+        assert hm.homeownership_rate == 0.5
+
+    def test_price_history_grows(self):
+        hm = HousingMarket()
+        hm.set_agents([], [], [], [])
+        hm.clear()
+        hm.clear()
+        assert len(hm.price_history) == 2
+
+    def test_get_state_keys(self):
+        hm = HousingMarket()
+        state = hm.get_state()
+        expected = {
+            "average_price",
+            "transactions",
+            "listings",
+            "months_supply",
+            "price_to_income",
+            "house_price_inflation",
+            "total_mortgage_lending",
+            "foreclosures",
+            "homeownership_rate",
+        }
+        assert set(state.keys()) == expected

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
+from pydantic import ValidationError
+
+from companies_house_abm.abm.config import load_config
+from companies_house_abm.webapp.app import _config_to_params, _params_to_config
+from companies_house_abm.webapp.models import SimulationParams
 
 
 class TestSimulationParams:
     """Tests for the expanded SimulationParams model."""
 
     def test_default_construction(self) -> None:
-        from companies_house_abm.webapp.models import SimulationParams
 
         p = SimulationParams()
         assert p.periods == 80
@@ -19,7 +25,6 @@ class TestSimulationParams:
         assert p.n_banks == 10
 
     def test_all_new_fields_present(self) -> None:
-        from companies_house_abm.webapp.models import SimulationParams
 
         p = SimulationParams()
         # Firms behaviour
@@ -77,9 +82,6 @@ class TestSimulationParams:
         assert p.default_rate_base == pytest.approx(0.01)
 
     def test_validation_rejects_out_of_range(self) -> None:
-        from pydantic import ValidationError
-
-        from companies_house_abm.webapp.models import SimulationParams
 
         with pytest.raises(ValidationError):
             SimulationParams(periods=5)  # below ge=10
@@ -96,8 +98,6 @@ class TestConfigToParams:
 
     def test_roundtrip_default_config(self) -> None:
         """Config → params → config should preserve all values."""
-        from companies_house_abm.abm.config import load_config
-        from companies_house_abm.webapp.app import _config_to_params, _params_to_config
 
         cfg = load_config()
         params = _config_to_params(cfg)
@@ -122,10 +122,6 @@ class TestConfigToParams:
 
     def test_clamping_of_large_sample_size(self) -> None:
         """Values exceeding Pydantic bounds are clamped, not rejected."""
-        import dataclasses
-
-        from companies_house_abm.abm.config import load_config
-        from companies_house_abm.webapp.app import _config_to_params
 
         cfg = load_config()
         # Patch in an oversized sample_size

--- a/uv.lock
+++ b/uv.lock
@@ -439,11 +439,14 @@ abm = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 dev = [
+    { name = "cryptography" },
     { name = "hatch" },
     { name = "prek" },
+    { name = "pygments" },
     { name = "pysentry-rs" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "requests" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -475,11 +478,14 @@ abm = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 dev = [
+    { name = "cryptography", specifier = ">=46.0.6" },
     { name = "hatch", specifier = ">=1.16.3" },
     { name = "prek", specifier = ">=0.1.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pysentry-rs", specifier = ">=0.1.0" },
     { name = "pytest", specifier = ">=9.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "ty", specifier = ">=0.0.14" },
 ]
@@ -772,51 +778,62 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.5"
+version = "46.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform == 'emscripten') or (python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform == 'win32') or (platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
-    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
-    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
-    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
-    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
-    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
-    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
+    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
+    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147, upload-time = "2026-03-25T23:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221, upload-time = "2026-03-25T23:33:49.874Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952, upload-time = "2026-03-25T23:33:52.128Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141, upload-time = "2026-03-25T23:33:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178, upload-time = "2026-03-25T23:33:55.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812, upload-time = "2026-03-25T23:33:57.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923, upload-time = "2026-03-25T23:33:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695, upload-time = "2026-03-25T23:34:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785, upload-time = "2026-03-25T23:34:02.796Z" },
+    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404, upload-time = "2026-03-25T23:34:04.35Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549, upload-time = "2026-03-25T23:34:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874, upload-time = "2026-03-25T23:34:07.916Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511, upload-time = "2026-03-25T23:34:09.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692, upload-time = "2026-03-25T23:34:11.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
+    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/7ccff00ced5bac74b775ce0beb7d1be4e8637536b522b5df9b73ada42da2/cryptography-46.0.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:2ea0f37e9a9cf0df2952893ad145fd9627d326a59daec9b0802480fa3bcd2ead", size = 3475444, upload-time = "2026-03-25T23:34:38.944Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1f/4c926f50df7749f000f20eede0c896769509895e2648db5da0ed55db711d/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a3e84d5ec9ba01f8fd03802b2147ba77f0c8f2617b2aff254cedd551844209c8", size = 4218227, upload-time = "2026-03-25T23:34:40.871Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/65/707be3ffbd5f786028665c3223e86e11c4cda86023adbc56bd72b1b6bab5/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:12f0fa16cc247b13c43d56d7b35287ff1569b5b1f4c5e87e92cc4fcc00cd10c0", size = 4381399, upload-time = "2026-03-25T23:34:42.609Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6d/73557ed0ef7d73d04d9aba745d2c8e95218213687ee5e76b7d236a5030fc/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:50575a76e2951fe7dbd1f56d181f8c5ceeeb075e9ff88e7ad997d2f42af06e7b", size = 4217595, upload-time = "2026-03-25T23:34:44.205Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c5/e1594c4eec66a567c3ac4400008108a415808be2ce13dcb9a9045c92f1a0/cryptography-46.0.6-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:90e5f0a7b3be5f40c3a0a0eafb32c681d8d2c181fc2a1bdabe9b3f611d9f6b1a", size = 4380912, upload-time = "2026-03-25T23:34:46.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/843b53614b47f97fe1abc13f9a86efa5ec9e275292c457af1d4a60dc80e0/cryptography-46.0.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6728c49e3b2c180ef26f8e9f0a883a2c585638db64cf265b49c9ba10652d430e", size = 3409955, upload-time = "2026-03-25T23:34:48.465Z" },
 ]
 
 [[package]]
@@ -969,6 +986,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -981,6 +999,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -989,6 +1008,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -2841,11 +2861,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -3160,7 +3180,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3168,9 +3188,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implement the housing market module based on Farmer (2025) and Baptista
et al. (2016), featuring bilateral matching, aspiration-level pricing,
FPC macroprudential mortgage evaluation, and full integration with the
existing economy simulation.

New components:
- Property and Mortgage dataclasses (abm/assets/)
- HousingMarket with bilateral matching (abm/markets/housing.py)
- HM Land Registry and ONS housing data fetchers
- Housing calibration from live UK data
- Comprehensive documentation (docs/housing-market.md)

Modified components:
- Household: tenure, buy/rent decisions, housing payments
- Bank: mortgage evaluation, origination, foreclosure
- Simulation: 16-phase step loop with housing phases
- Config: PropertyConfig, HousingMarketConfig, MortgageConfig
- Webapp: housing parameters and period data

351 tests passing (39 new housing tests, 0 regressions).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>