### PR TITLE
refactor(uk-data): apply schema-on-read pipeline to ONSAdapter

### DIFF
--- a/packages/uk-data/src/uk_data/adapters/base.py
+++ b/packages/uk-data/src/uk_data/adapters/base.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from uk_data.models import Entity, Event, TimeSeries
+    from uk_data.storage.canonical import CanonicalStore
     from uk_data.storage.raw import RawStore
 
 
@@ -64,8 +65,14 @@ class BaseAdapter(ABC):  # noqa: B024
 
     _source_name: str = "unknown"
 
-    def __init__(self, store: RawStore | None = None) -> None:
+    def __init__(
+        self,
+        store: RawStore | None = None,
+        *,
+        canonical_store: CanonicalStore | None = None,
+    ) -> None:
         self._store = store
+        self._canonical = canonical_store
 
     # ------------------------------------------------------------------
     # Raw storage helpers

--- a/packages/uk-data/src/uk_data/adapters/ons.py
+++ b/packages/uk-data/src/uk_data/adapters/ons.py
@@ -1,21 +1,29 @@
-"""ONS (Office for National Statistics) data fetcher.
+"""ONS (Office for National Statistics) data adapter.
 
-Wraps the ONS API (https://api.ons.gov.uk/v1/) and selected static datasets
-to provide UK macroeconomic and housing data for ABM calibration.
+Wraps the ONS dataset API (https://api.beta.ons.gov.uk/v1/) using a
+three-stage schema-on-read pipeline:
+
+1. :meth:`ONSAdapter.extract` fetches raw observation JSON for a given
+   ``(dataset_id, edition, version, **dimensions)`` tuple and persists it
+   to the configured :class:`~uk_data.storage.raw.RawStore` *unvalidated*.
+2. :meth:`ONSAdapter.transform` loads a previously extracted raw payload,
+   validates it through pydantic (:class:`~uk_data.adapters.ons_models.ONSObservation`),
+   builds a canonical :class:`~uk_data.models.TimeSeries`, and upserts it to
+   the configured :class:`~uk_data.storage.canonical.CanonicalStore`.
+3. :meth:`ONSAdapter.fetch_series` reads only from the canonical store; it
+   raises :class:`FileNotFoundError` if no extract+transform has run for the
+   requested series.
 
 Datasets used
 -------------
-- **ABMI** - UK GDP at market prices (GBP million, seasonally adjusted,
+- **ABMI** - UK GDP at market prices (GBP million, seasonally adjusted, quarterly).
+- **RPHQ** - UK households' disposable income (GBP million, seasonally adjusted,
   quarterly).
-- **RPHQ** - UK households' disposable income (GBP million, seasonally
-  adjusted, quarterly).
 - **NRJS** - Household saving ratio (%), seasonally adjusted, quarterly.
 - **MGSX** / **KAB9** - Labour Force Survey: unemployment rate and average
   weekly earnings.
 - **HP7A** - House price to workplace-based earnings affordability ratio.
 - **D7RA** - Index of Private Housing Rental Prices (monthly).
-- **Supply and Use Tables** - ONS Input-Output supply and use tables
-  (parsed into a coefficient matrix).
 
 All data is Crown Copyright, reproduced under the Open Government Licence.
 See https://www.ons.gov.uk/methodology/geography/licences for details.
@@ -26,9 +34,11 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 if TYPE_CHECKING:
+    from uk_data.models.timeseries import TimeSeries
+    from uk_data.storage.canonical import CanonicalStore
     from uk_data.storage.raw import RawStore
 
 from uk_data.adapters.base import BaseAdapter
@@ -39,105 +49,32 @@ from uk_data.adapters.ons_models import (
     ONSObservation,
 )
 from uk_data.transformers.timeseries import (
-    TimeSeriesTransformer,
+    frame_to_timeseries,
     series_from_observations,
+    timeseries_to_frame,
 )
 from uk_data.utils.http import get_json, retry
-from uk_data.utils.timeseries import filter_observations_by_date_window
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# ONS API root
-# ---------------------------------------------------------------------------
-
 _ONS_API = "https://api.beta.ons.gov.uk/v1"
 
-# ---------------------------------------------------------------------------
-# Dataset series IDs
-# ---------------------------------------------------------------------------
+# Canonical Parquet path used by transform()/fetch_series() under the
+# CanonicalStore root.
+_CANONICAL_PATH = "timeseries/ons.parquet"
 
-# UK GDP at market prices (SA, GBP m, quarterly)
+# Series IDs ----------------------------------------------------------------
+
 _GDP_SERIES = "ABMI"
-
-# Households' & NPISH gross disposable income (SA, GBP m, quarterly)
 _HOUSEHOLD_INCOME_SERIES = "RPHQ"
-
-# HH & NPISH saving ratio (%, SA, quarterly)
 _SAVINGS_RATIO_SERIES = "NRJS"
-
-# Unemployment rate (%, SA, monthly)
 _UNEMPLOYMENT_RATE_SERIES = "MGSX"
-
-# Average weekly earnings (GBP, SA, monthly)
 _AVERAGE_EARNINGS_SERIES = "KAB9"
-
-# House price to workplace-based earnings affordability ratio (annual)
 _AFFORDABILITY_SERIES = "HP7A"
-
-# Index of Private Housing Rental Prices (monthly)
 _RENTAL_INDEX_SERIES = "D7RA"
 
-# ---------------------------------------------------------------------------
-# Fallback values for housing statistics
-# ---------------------------------------------------------------------------
-
-# English Housing Survey 2023-24 tenure shares
-_FALLBACK_TENURE: dict[str, float] = {
-    "owner_occupier": 0.64,
-    "private_renter": 0.19,
-    "social_renter": 0.17,
-}
-
-# ONS affordability ratio (median house price / median workplace earnings)
-_FALLBACK_AFFORDABILITY = 8.3
-
-# Annual private rental price growth (ONS IPHRP, 2024)
-_FALLBACK_RENTAL_GROWTH = 0.065
-
-# ---------------------------------------------------------------------------
-# Series → ONS Zebedee content URI mapping
-#
-# The ONS Zebedee reader API uses GET /v1/data?uri=<path> where <path> is
-# the full content URI for the timeseries page on ons.gov.uk.  The old
-# /v1/timeseries/{id}/dataset/{dataset}/data path pattern is no longer
-# served (returns 404).
-#
-# URIs confirmed against the live API.  Series not listed here fall back to
-# the _DEFAULT_URI_TEMPLATE which uses the GDP topic and ukea dataset —
-# suitable for national-accounts series.
-# ---------------------------------------------------------------------------
-
-_SERIES_URI: dict[str, str] = {
-    # National accounts (UK Economic Accounts / GDP topic)
-    "ABMI": "/economy/grossdomesticproductgdp/timeseries/abmi/ukea",
-    "RPHQ": "/economy/grossdomesticproductgdp/timeseries/rphq/ukea",
-    "NRJS": "/economy/grossdomesticproductgdp/timeseries/nrjs/ukea",
-    # Labour market (Labour Market Statistics bulletin)
-    "MGSX": (
-        "/employmentandlabourmarket/peoplenotinwork/unemployment/timeseries/mgsx/lms"
-    ),
-    "KAB9": (
-        "/employmentandlabourmarket/peopleinwork"
-        "/earningsandworkinghours/timeseries/kab9/lms"
-    ),
-    # GVA by industry (UK Economic Accounts) — confirmed working subset.
-    # L2KL: Agriculture; L2N8: Construction; L2NC: Total Services;
-    # L2NE: Wholesale & Retail Trade.  Other SIC-division series
-    # (L2KP, L2ND, L2NF-L2NM) return 404 from the Zebedee API and are
-    # therefore omitted.  These are consumed by the ABM's input-output
-    # table builder (see companies_house_abm.data_sources.input_output).
-    "L2KL": "/economy/grossdomesticproductgdp/timeseries/l2kl/ukea",
-    "L2N8": "/economy/grossdomesticproductgdp/timeseries/l2n8/ukea",
-    "L2NC": "/economy/grossdomesticproductgdp/timeseries/l2nc/ukea",
-    "L2NE": "/economy/grossdomesticproductgdp/timeseries/l2ne/ukea",
-    # HP7A (affordability ratio) and D7RA (rental index) are not
-    # available via the Zebedee API; fetch_affordability_ratio and
-    # fetch_rental_growth use their hardcoded fallback values.
-}
-
-_DEFAULT_URI_TEMPLATE = "/economy/grossdomesticproductgdp/timeseries/{sid}/ukea"
-
+# Series → human-readable metadata used by transform() to build the canonical
+# TimeSeries. Keyed by upper-case ONS time-series identifier.
 _SERIES_METADATA: dict[str, dict[str, str]] = {
     "ABMI": {
         "concept": "gdp",
@@ -190,54 +127,147 @@ _SERIES_METADATA: dict[str, dict[str, str]] = {
     },
 }
 
+# Series → ONS dataset-API extract parameters.
+#
+# Each entry maps an ONS time-series ID to the ``(dataset_id, edition,
+# version, dimensions)`` tuple that ``extract()`` will request. The five
+# national-accounts / labour-market series live under the ``ukea`` and
+# ``lms`` time-series datasets; HP7A and D7RA live in their own
+# topic-specific datasets.
+#
+# The HP7A / D7RA dataset_ids have not been verified against the live API
+# from this sandbox. If they turn out to differ from the values below, the
+# workflow-level helpers in ``uk_data.workflows.ons`` will fall back to the
+# package-level constants documented in that module so calibration remains
+# robust until the IDs are corrected.
+_SERIES_DATASET: dict[str, dict[str, Any]] = {
+    "ABMI": {
+        "dataset_id": "ukea",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "ABMI", "time": "*"},
+    },
+    "RPHQ": {
+        "dataset_id": "ukea",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "RPHQ", "time": "*"},
+    },
+    "NRJS": {
+        "dataset_id": "ukea",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "NRJS", "time": "*"},
+    },
+    "MGSX": {
+        "dataset_id": "lms",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "MGSX", "time": "*"},
+    },
+    "KAB9": {
+        "dataset_id": "lms",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "KAB9", "time": "*"},
+    },
+    "HP7A": {
+        "dataset_id": "housing-affordability-in-england-and-wales",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "HP7A", "time": "*"},
+    },
+    "D7RA": {
+        "dataset_id": "index-of-private-housing-rental-prices",
+        "edition": "time-series",
+        "version": "latest",
+        "dimensions": {"timeseries": "D7RA", "time": "*"},
+    },
+}
 
-def _fetch_timeseries(series_id: str, limit: int = 20) -> list[dict[str, Any]]:
-    """Fetch the latest *limit* observations for an ONS time series.
 
-    Uses the ONS Zebedee reader API (``GET /v1/data?uri=<path>``).  Each
-    series has a content URI registered in ``_SERIES_URI``; unknown series
-    fall back to the GDP topic template.
+def _fetch_timeseries(series_id: str, limit: int = 20) -> list[dict[str, str]]:
+    """Return the latest *limit* observations for an ONS time series.
+
+    Backward-compatibility helper for callers that pre-date the
+    schema-on-read pipeline. Hits the dataset-API observations endpoint
+    directly (via ``retry(get_json, url)``) and returns the unvalidated
+    payload reduced to ``[{"date": ..., "value": ...}, ...]``.
 
     Args:
-        series_id: ONS time-series identifier (e.g. ``"ABMI"``).
+        series_id: ONS time-series identifier (e.g. ``"ABMI"``, ``"L2KL"``).
         limit: Maximum number of observations to return (most recent first).
 
     Returns:
-        List of observation dicts with keys ``"date"`` (str) and
-        ``"value"`` (str).
+        List of observation dicts ``{"date": str, "value": str}``, oldest
+        first. Returns ``[]`` on any API failure.
     """
-    sid_upper = series_id.upper()
-    content_uri = _SERIES_URI.get(
-        sid_upper,
-        _DEFAULT_URI_TEMPLATE.format(sid=series_id.lower()),
+    sid = series_id.upper()
+    cfg = _SERIES_DATASET.get(sid)
+    if cfg is not None:
+        dataset_id = cfg["dataset_id"]
+        edition = cfg["edition"]
+        version = cfg["version"]
+        dimensions = dict(cfg["dimensions"])
+    else:
+        dataset_id = "ukea"
+        edition = "time-series"
+        version = "latest"
+        dimensions = {"timeseries": sid, "time": "*"}
+
+    base = (
+        f"{_ONS_API}/datasets/{dataset_id}/editions/{edition}/versions/{version}"
+        "/observations"
     )
-    url = f"{_ONS_API}/data?uri={quote(content_uri, safe='/')}"
+    params = {k: v for k, v in dimensions.items() if isinstance(v, str)}
+    url = f"{base}?{urlencode(params)}" if params else base
+
     try:
-        data = retry(get_json, url)
+        payload = retry(get_json, url)
     except Exception:
         logger.warning("ONS API unavailable for series %s, returning []", series_id)
         return []
 
-    # The ONS API returns observations in frequency-keyed arrays:
-    # "quarters" for quarterly series, "months" for monthly, "years" for annual.
-    observations: list[dict[str, Any]] = (
-        data.get("quarters")
-        or data.get("months")
-        or data.get("years")
-        or data.get("observations")
-        or []
-    )
+    observations: list[dict[str, str]] = []
+    if isinstance(payload, dict):
+        # Dataset API: {"observations": [{"dimensions": {"time": {"id": ...}},
+        #                                  "observation": "..."}, ...]}
+        raw_rows = payload.get("observations") or []
+        for row in raw_rows:
+            if not isinstance(row, dict):
+                continue
+            dims = row.get("dimensions") or {}
+            time_dim = dims.get("time") if isinstance(dims, dict) else None
+            date_id: str | None = None
+            if isinstance(time_dim, dict):
+                date_id = time_dim.get("id")
+            value = row.get("observation")
+            if date_id and value not in (None, ""):
+                observations.append({"date": str(date_id), "value": str(value)})
+
+        # Legacy Zebedee-shape payload (used by older test fixtures): the
+        # observations are bucketed under "quarters"/"months"/"years".
+        if not observations:
+            legacy = (
+                payload.get("quarters")
+                or payload.get("months")
+                or payload.get("years")
+                or []
+            )
+            for row in legacy:
+                if isinstance(row, dict) and row.get("value") not in (None, ""):
+                    date_str = str(row.get("date", ""))
+                    observations.append({"date": date_str, "value": str(row["value"])})
+
     return observations[-limit:] if len(observations) > limit else observations
 
 
 def _latest_float(series_id: str) -> float | None:
     """Return the most recent numeric value for an ONS time series.
 
-    Args:
-        series_id: ONS time-series identifier.
-
-    Returns:
-        The latest observation as a float, or ``None`` if unavailable.
+    Backward-compatibility helper used by
+    :mod:`companies_house_abm.data_sources.input_output` to read GVA series
+    by ID without going through the full extract+transform pipeline.
     """
     obs = _fetch_timeseries(series_id, limit=1)
     if not obs:
@@ -248,58 +278,40 @@ def _latest_float(series_id: str) -> float | None:
         return None
 
 
-# ---------------------------------------------------------------------------
-# Public fetch functions
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Housing statistics (private helpers — public interface in workflows/ons.py)
-# ---------------------------------------------------------------------------
-
-
-def _fetch_affordability_ratio() -> float:
-    """Return the median house price to earnings affordability ratio."""
-    try:
-        obs = _fetch_timeseries(_AFFORDABILITY_SERIES, limit=1)
-        if obs:
-            value = float(obs[-1]["value"])
-            if value > 0:
-                logger.info("Fetched affordability ratio: %.1f", value)
-                return value
-    except Exception:
-        logger.warning("ONS affordability series unavailable, using fallback")
-
-    return _FALLBACK_AFFORDABILITY
-
-
-def _fetch_rental_growth() -> float:
-    """Return the annual private rental price growth rate."""
-    try:
-        obs = _fetch_timeseries(_RENTAL_INDEX_SERIES, limit=13)
-        if len(obs) >= 13:
-            latest = float(obs[-1]["value"])
-            year_ago = float(obs[0]["value"])
-            if year_ago > 0 and latest > 0:
-                growth = (latest / year_ago) - 1.0
-                logger.info("Fetched rental growth: %.1f%%", growth * 100)
-                return growth
-    except Exception:
-        logger.warning("ONS rental index unavailable, using fallback")
-
-    return _FALLBACK_RENTAL_GROWTH
+def _coerce_iso_date(value: object) -> str | None:
+    """Coerce a date-bound input to an ISO-8601 ``YYYY-MM-DD`` string."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    msg = f"Invalid ONS date bound: {value!r}"
+    raise ValueError(msg)
 
 
 class ONSAdapter(BaseAdapter):
-    """Canonical adapter for Office for National Statistics data."""
+    """Schema-on-read adapter for Office for National Statistics data."""
 
     _source_name = "ons"
 
-    def __init__(self, store: RawStore | None = None) -> None:
-        super().__init__(store=store)
+    def __init__(
+        self,
+        store: RawStore | None = None,
+        *,
+        canonical_store: CanonicalStore | None = None,
+    ) -> None:
+        super().__init__(store=store, canonical_store=canonical_store)
         self._datasets_cache: dict[
             tuple[int, int, str | None], list[ONSDatasetInfo]
         ] = {}
+
+    # ------------------------------------------------------------------
+    # URL helpers
+    # ------------------------------------------------------------------
 
     def _build_dataset_url(
         self, path: str, *, params: dict[str, str] | None = None
@@ -318,49 +330,45 @@ class ONSAdapter(BaseAdapter):
         msg = f"Invalid ONS limit value: {value!r}"
         raise ValueError(msg)
 
-    @staticmethod
-    def _coerce_date_bound(value: object) -> str | date | datetime | None:
-        if value is None:
-            return None
-        if isinstance(value, (str, date, datetime)):
-            return value
-        msg = f"Invalid ONS date bound: {value!r}"
-        raise ValueError(msg)
+    # ------------------------------------------------------------------
+    # Raw key construction
+    # ------------------------------------------------------------------
 
     @staticmethod
-    def _series_dataset_id(series_id: str) -> str:
-        if series_id in {_UNEMPLOYMENT_RATE_SERIES, _AVERAGE_EARNINGS_SERIES}:
-            return "lms"
-        return "ukea"
-
-    def _fetch_series_observations(self, series_id: str) -> list[dict[str, str]]:
-        dataset_id = self._series_dataset_id(series_id)
-        rows = self.get_observation_series(
-            dataset_id,
-            "time-series",
-            "latest",
-            timeseries=series_id,
-            time="*",
-        )
-        return [
-            {"date": date_id, "value": str(item.observation)}
-            for item in rows
-            if (date_id := item.dimensions.get_time_id())
-        ]
-
-    def get_observation_series(
-        self,
+    def _raw_key(
         dataset_id: str,
         edition: str,
         version: str | int,
-        **dimensions: str,
-    ) -> list[Observation]:
-        """Return individual observation rows from a dataset endpoint."""
-        return self.get_observation(
-            dataset_id, edition, version, **dimensions
-        ).observations
+        dimensions: dict[str, str],
+    ) -> str:
+        """Build a deterministic, filesystem-safe RawStore key."""
+        dim_part = "_".join(
+            f"{k}={v}" for k, v in sorted(dimensions.items()) if isinstance(v, str)
+        )
+        return (
+            f"{dataset_id}/{edition}/{version}/{dim_part}"
+            if dim_part
+            else f"{dataset_id}/{edition}/{version}"
+        )
 
-    def list_datasets(
+    @staticmethod
+    def _series_id_for_key(key: str) -> str:
+        """Recover the ``timeseries`` dimension from a RawStore key."""
+        last = key.rsplit("/", maxsplit=1)[-1]
+        for chunk in last.split("_"):
+            if "=" not in chunk:
+                continue
+            k, v = chunk.split("=", maxsplit=1)
+            if k == "timeseries":
+                return v.upper()
+        msg = f"Cannot recover series_id from key: {key!r}"
+        raise ValueError(msg)
+
+    # ------------------------------------------------------------------
+    # Discovery API — kept typed (no schema-on-read)
+    # ------------------------------------------------------------------
+
+    def get_datasets(
         self,
         *,
         limit: int = 20,
@@ -414,6 +422,7 @@ class ONSAdapter(BaseAdapter):
         version: str | int,
         **dimensions: str,
     ) -> ONSObservation:
+        """Query the observations endpoint and return a typed payload."""
         url = self._build_dataset_url(
             f"datasets/{dataset_id}/editions/{edition}/versions/{version}/observations"
         )
@@ -421,6 +430,141 @@ class ONSAdapter(BaseAdapter):
         full_url = f"{url}?{urlencode(params)}" if params else url
         payload = get_json(full_url)
         return ONSObservation.model_validate(payload)
+
+    def get_observation_series(
+        self,
+        dataset_id: str,
+        edition: str,
+        version: str | int,
+        **dimensions: str,
+    ) -> list[Observation]:
+        """Return individual observation rows from a dataset endpoint."""
+        return self.get_observation(
+            dataset_id, edition, version, **dimensions
+        ).observations
+
+    # ------------------------------------------------------------------
+    # Stage 1: extract — fetch raw JSON, write to RawStore, no validation
+    # ------------------------------------------------------------------
+
+    def extract(
+        self,
+        dataset_id: str,
+        edition: str,
+        version: str | int,
+        **dimensions: str,
+    ) -> str:
+        """Fetch raw observation JSON and persist it to the RawStore.
+
+        ``dataset_id`` corresponds to :attr:`ONSDatasetInfo.id` returned by
+        :meth:`get_datasets`. ``edition`` and ``version`` select the snapshot;
+        ``dimensions`` filter the observation rows.
+
+        No pydantic validation is performed here — the unparsed JSON is
+        written verbatim. Use :meth:`transform` to validate and convert it
+        into a canonical :class:`~uk_data.models.TimeSeries`.
+
+        Args:
+            dataset_id: ONS dataset identifier.
+            edition: Edition slug (e.g. ``"time-series"``).
+            version: Version identifier (e.g. ``"latest"`` or an integer).
+            **dimensions: Dimension filters (e.g. ``timeseries="ABMI"``,
+                ``time="*"``).
+
+        Returns:
+            The RawStore key under which the payload was written. Pass this
+            to :meth:`transform`.
+        """
+        url = self._build_dataset_url(
+            f"datasets/{dataset_id}/editions/{edition}/versions/{version}/observations"
+        )
+        params = {k: v for k, v in dimensions.items() if isinstance(v, str)}
+        full_url = f"{url}?{urlencode(params)}" if params else url
+        payload = get_json(full_url)
+        key = self._raw_key(dataset_id, edition, version, params)
+        self.save(key, payload)
+        return key
+
+    def extract_series(self, series_id: str) -> str:
+        """Convenience wrapper: extract the raw payload for a known series ID.
+
+        Looks up the dataset/edition/version/dimensions from the
+        ``_SERIES_DATASET`` registry and forwards to :meth:`extract`.
+        """
+        sid = series_id.upper()
+        if sid not in _SERIES_DATASET:
+            msg = f"Unsupported ONS series for extract_series: {series_id}"
+            raise ValueError(msg)
+        cfg = _SERIES_DATASET[sid]
+        return self.extract(
+            cfg["dataset_id"],
+            cfg["edition"],
+            cfg["version"],
+            **cfg["dimensions"],
+        )
+
+    # ------------------------------------------------------------------
+    # Stage 2: transform — load raw, validate, write canonical
+    # ------------------------------------------------------------------
+
+    def transform(self, key: str) -> TimeSeries:
+        """Load a raw payload from the RawStore and persist canonical rows.
+
+        Validates the raw JSON via
+        :class:`~uk_data.adapters.ons_models.ONSObservation`, builds a
+        canonical :class:`~uk_data.models.TimeSeries`, and upserts it into
+        the configured :class:`~uk_data.storage.canonical.CanonicalStore`
+        at ``timeseries/ons.parquet``.
+
+        Args:
+            key: RawStore key returned by :meth:`extract` /
+                :meth:`extract_series`.
+
+        Returns:
+            The canonical :class:`~uk_data.models.TimeSeries` produced.
+
+        Raises:
+            FileNotFoundError: If no raw payload exists for *key*.
+            ValueError: If the raw payload's series ID is unknown.
+        """
+        raw = self.load(key)
+        if raw is None:
+            msg = f"No raw payload found for key={key!r}"
+            raise FileNotFoundError(msg)
+
+        parsed = ONSObservation.model_validate(raw)
+        observations = [
+            {"date": date_id, "value": str(item.observation)}
+            for item in parsed.observations
+            if (date_id := item.dimensions.get_time_id())
+        ]
+
+        series_id = self._series_id_for_key(key)
+        metadata = _SERIES_METADATA.get(series_id)
+        if metadata is None:
+            msg = f"Unsupported ONS series in raw key {key!r}: {series_id}"
+            raise ValueError(msg)
+
+        ts = series_from_observations(
+            series_id=metadata["concept"],
+            name=metadata["name"],
+            frequency=metadata["frequency"],
+            units=metadata["units"],
+            seasonal_adjustment=metadata["seasonal_adjustment"],
+            geography="UK",
+            observations=observations,
+            source="ons",
+            source_series_id=series_id,
+        )
+
+        if self._canonical is not None and ts.values.size > 0:
+            self._canonical.upsert(timeseries_to_frame(ts), _CANONICAL_PATH)
+
+        return ts
+
+    # ------------------------------------------------------------------
+    # Stage 3: fetch_series — read canonical only
+    # ------------------------------------------------------------------
 
     def available_series(self) -> list[str]:
         """Return the ONS series IDs supported by this adapter."""
@@ -434,76 +578,68 @@ class ONSAdapter(BaseAdapter):
             _RENTAL_INDEX_SERIES,
         ]
 
-    def fetch_series(self, series_id: str, **kwargs: object):
-        """Fetch a canonical ONS time series."""
-        series_id = series_id.upper()
-        metadata = _SERIES_METADATA.get(series_id)
-        if metadata is None:
+    def fetch_series(self, series_id: str, **kwargs: object) -> TimeSeries:
+        """Read a canonical ONS time series from the canonical store.
+
+        Args:
+            series_id: ONS series identifier (case-insensitive).
+            **kwargs: Optional ``start_date``, ``end_date``, ``limit``.
+
+        Returns:
+            The canonical :class:`~uk_data.models.TimeSeries` filtered by the
+            provided date window and (optional) ``limit``.
+
+        Raises:
+            ValueError: If *series_id* is not in :meth:`available_series`.
+            FileNotFoundError: If no canonical store is configured, or if
+                the canonical Parquet file does not yet contain rows for
+                *series_id*. Run :meth:`extract_series` and :meth:`transform`
+                first.
+        """
+        sid = series_id.upper()
+        if sid not in _SERIES_METADATA:
             msg = f"Unsupported ONS series: {series_id}"
             raise ValueError(msg)
+        if self._canonical is None:
+            msg = (
+                "ONSAdapter has no canonical store configured; "
+                "run extract+transform with a CanonicalStore first."
+            )
+            raise FileNotFoundError(msg)
 
+        start_iso = _coerce_iso_date(kwargs.get("start_date"))
+        end_iso = _coerce_iso_date(kwargs.get("end_date"))
         limit = self._coerce_limit(kwargs.get("limit", 20))
-        start_date = self._coerce_date_bound(kwargs.get("start_date"))
-        end_date = self._coerce_date_bound(kwargs.get("end_date"))
-        concept = str(kwargs.get("concept", metadata["concept"]))
 
-        if series_id in {
-            _GDP_SERIES,
-            _HOUSEHOLD_INCOME_SERIES,
-            _SAVINGS_RATIO_SERIES,
-            _UNEMPLOYMENT_RATE_SERIES,
-            _AVERAGE_EARNINGS_SERIES,
-        }:
-            observations = self._fetch_series_observations(series_id)
-            observations = filter_observations_by_date_window(
-                observations,
-                start_date=start_date,
-                end_date=end_date,
+        try:
+            frame = self._canonical.query_typed(
+                _CANONICAL_PATH,
+                entity=sid,
+                start=start_iso,
+                end=end_iso,
             )
-            if limit >= 0:
-                observations = observations[-limit:]
-            return series_from_observations(
-                series_id=concept,
-                name=metadata["name"],
-                frequency=metadata["frequency"],
-                units=metadata["units"],
-                seasonal_adjustment=metadata["seasonal_adjustment"],
-                geography="UK",
-                observations=observations,
-                source="ons",
-                source_series_id=series_id,
+        except FileNotFoundError as exc:
+            msg = (
+                f"No canonical ONS data for series_id={sid!r}; "
+                "run extract+transform first."
             )
+            raise FileNotFoundError(msg) from exc
 
-        if series_id == _AFFORDABILITY_SERIES:
-            return TimeSeriesTransformer.point(
-                series_id=concept,
-                name=metadata["name"],
-                value=_fetch_affordability_ratio(),
-                units=metadata["units"],
-                source="ons",
-                source_series_id=series_id,
-                frequency=metadata["frequency"],
-                seasonal_adjustment=metadata["seasonal_adjustment"],
-                geography="UK",
-                metadata={"source_quality": "fallback"},
+        if frame.is_empty():
+            msg = (
+                f"No canonical ONS data for series_id={sid!r}; "
+                "run extract+transform first."
             )
+            raise FileNotFoundError(msg)
 
-        if series_id == _RENTAL_INDEX_SERIES:
-            return TimeSeriesTransformer.point(
-                series_id=concept,
-                name=metadata["name"],
-                value=_fetch_rental_growth(),
-                units=metadata["units"],
-                source="ons",
-                source_series_id=series_id,
-                frequency=metadata["frequency"],
-                seasonal_adjustment=metadata["seasonal_adjustment"],
-                geography="UK",
-                metadata={"source_quality": "fallback"},
-            )
+        if limit >= 0:
+            frame = frame.tail(limit)
 
-        msg = f"Unsupported ONS transport branch for series: {series_id}"
-        raise ValueError(msg)
+        return frame_to_timeseries(frame, series_id=sid)
+
+    # ------------------------------------------------------------------
+    # Entity / event surface (unchanged)
+    # ------------------------------------------------------------------
 
     def available_entity_types(self) -> list[str]:
         """ONS adapter does not support entity lookup."""

--- a/packages/uk-data/src/uk_data/client.py
+++ b/packages/uk-data/src/uk_data/client.py
@@ -26,7 +26,7 @@ class UKDataClient:
 
     def __init__(self, *, canonical_store: CanonicalStore | None = None) -> None:
         self.adapters = {
-            "ons": ONSAdapter(),
+            "ons": ONSAdapter(canonical_store=canonical_store),
             "boe": BoEAdapter(),
             "hmrc": HMRCAdapter(),
             "land_registry": LandRegistryAdapter(),

--- a/packages/uk-data/src/uk_data/transformers/timeseries.py
+++ b/packages/uk-data/src/uk_data/transformers/timeseries.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import numpy as np
+import polars as pl
 
 from uk_data.models.timeseries import TimeSeries, _parse_timestamp
 
@@ -124,6 +125,111 @@ def point_timeseries(
         source=source,
         source_series_id=source_series_id,
         last_updated=point,
+    )
+
+
+_FRAME_COLUMNS: tuple[str, ...] = (
+    "source",
+    "entity_id",
+    "timestamp",
+    "value",
+    "concept",
+    "name",
+    "frequency",
+    "units",
+    "seasonal_adjustment",
+    "geography",
+    "source_quality",
+    "last_updated",
+)
+
+
+def timeseries_to_frame(ts: TimeSeries) -> pl.DataFrame:
+    """Render a :class:`~uk_data.models.TimeSeries` as a canonical Polars frame.
+
+    The frame's column layout matches the schema expected by
+    :meth:`uk_data.storage.canonical.CanonicalStore.upsert` — ``source``,
+    ``entity_id`` (=``source_series_id``), and ``timestamp`` form the
+    composite key.
+    """
+    n = int(ts.values.shape[0])
+    quality = str(ts.metadata.get("source_quality", "live"))
+    last_updated = (
+        ts.last_updated.astimezone(UTC).replace(tzinfo=None)
+        if ts.last_updated.tzinfo
+        else ts.last_updated
+    )
+    return pl.DataFrame(
+        {
+            "source": [ts.source] * n,
+            "entity_id": [ts.source_series_id] * n,
+            "timestamp": ts.timestamps.astype("datetime64[us]").tolist(),
+            "value": ts.values.tolist(),
+            "concept": [ts.series_id] * n,
+            "name": [ts.name] * n,
+            "frequency": [ts.frequency] * n,
+            "units": [ts.units] * n,
+            "seasonal_adjustment": [ts.seasonal_adjustment] * n,
+            "geography": [ts.geography] * n,
+            "source_quality": [quality] * n,
+            "last_updated": [last_updated] * n,
+        },
+        schema={
+            "source": pl.Utf8,
+            "entity_id": pl.Utf8,
+            "timestamp": pl.Datetime("us"),
+            "value": pl.Float64,
+            "concept": pl.Utf8,
+            "name": pl.Utf8,
+            "frequency": pl.Utf8,
+            "units": pl.Utf8,
+            "seasonal_adjustment": pl.Utf8,
+            "geography": pl.Utf8,
+            "source_quality": pl.Utf8,
+            "last_updated": pl.Datetime("us"),
+        },
+    )
+
+
+def frame_to_timeseries(frame: pl.DataFrame, *, series_id: str) -> TimeSeries:
+    """Reconstruct a canonical :class:`~uk_data.models.TimeSeries` from a frame.
+
+    Filters by ``entity_id == series_id``, sorts by ``timestamp``, and pulls
+    the static metadata columns from the first surviving row.
+    """
+    selected = frame.filter(pl.col("entity_id") == series_id).sort("timestamp")
+    if selected.is_empty():
+        msg = f"No rows in frame for entity_id={series_id!r}"
+        raise ValueError(msg)
+    head = selected.row(0, named=True)
+    timestamps = selected["timestamp"].to_numpy().astype("datetime64[ns]")
+    values = selected["value"].to_numpy().astype(np.float64)
+    metadata: dict[str, Any] = {}
+    quality = head.get("source_quality")
+    if quality:
+        metadata["source_quality"] = quality
+    last_updated_raw = head.get("last_updated")
+    last_updated: datetime
+    if isinstance(last_updated_raw, datetime):
+        if last_updated_raw.tzinfo:
+            last_updated = last_updated_raw
+        else:
+            last_updated = last_updated_raw.replace(tzinfo=UTC)
+    else:
+        last_updated = datetime.now(UTC)
+    return TimeSeries(
+        series_id=str(head["concept"]),
+        name=str(head["name"]),
+        frequency=str(head["frequency"]),
+        units=str(head["units"]),
+        seasonal_adjustment=str(head["seasonal_adjustment"]),
+        geography=str(head["geography"]),
+        timestamps=timestamps,
+        values=values,
+        metadata=metadata,
+        source=str(head["source"]),
+        source_series_id=str(head["entity_id"]),
+        last_updated=last_updated,
     )
 
 

--- a/packages/uk-data/src/uk_data/workflows/ons.py
+++ b/packages/uk-data/src/uk_data/workflows/ons.py
@@ -1,28 +1,27 @@
-"""High-level ONS fetch functions for use in ABM calibration workflows.
+"""High-level ONS fetch helpers used by ABM calibration workflows.
 
-These orchestration functions wrap the low-level ONS adapter helpers and
-provide the public interface consumed by ``companies_house_abm`` and other
-downstream packages.  The adapter implementation details (HTTP, retry logic,
-fallback constants) remain private to ``uk_data.adapters.ons``.
+These wrap the typed ONS dataset-API surface and present a stable,
+calibration-friendly shape (lists of observation dicts, latest floats).
+Callers that need canonical persistence should drive the
+:class:`~uk_data.adapters.ons.ONSAdapter` schema-on-read pipeline directly
+via ``extract_series`` → ``transform`` → ``fetch_series``.
+
+Each helper:
+- accepts optional ``start_date`` / ``end_date`` parameters so callers can
+  window the returned observations,
+- returns a documented fallback (empty list, ``None``, or a workflow-level
+  constant) when the upstream API is unavailable, so calibration code
+  remains robust.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import date, datetime
 from typing import Any
 
-from uk_data.adapters.ons import (
-    _AVERAGE_EARNINGS_SERIES,
-    _FALLBACK_TENURE,
-    _GDP_SERIES,
-    _HOUSEHOLD_INCOME_SERIES,
-    _SAVINGS_RATIO_SERIES,
-    _UNEMPLOYMENT_RATE_SERIES,
-    _fetch_affordability_ratio,
-    _fetch_rental_growth,
-    _fetch_timeseries,
-    _latest_float,
-)
+from uk_data.adapters.ons import _fetch_timeseries, _latest_float
+from uk_data.utils.timeseries import filter_observations_by_date_window
 
 logger = logging.getLogger(__name__)
 
@@ -36,122 +35,190 @@ __all__ = [
     "fetch_tenure_distribution",
 ]
 
+# ---------------------------------------------------------------------------
+# Workflow-level fallbacks
+#
+# When the ONS API is unavailable, these constants keep the calibration
+# pipeline robust. They previously lived inside the adapter; moving them to
+# the workflow layer keeps the adapter surface fallback-free.
+# ---------------------------------------------------------------------------
 
-def fetch_gdp(limit: int = 20) -> list[dict[str, Any]]:
-    """Fetch recent UK GDP at market prices observations.
+# English Housing Survey 2023-24 tenure shares (no live API equivalent).
+_FALLBACK_TENURE: dict[str, float] = {
+    "owner_occupier": 0.64,
+    "private_renter": 0.19,
+    "social_renter": 0.17,
+}
 
-    Data is sourced from the ONS time series ``ABMI`` (seasonally
-    adjusted, current prices, GBP million).
+# ONS affordability ratio (median house price / median workplace earnings).
+_FALLBACK_AFFORDABILITY = 8.3
+
+# Annual private rental price growth (ONS IPHRP, 2024).
+_FALLBACK_RENTAL_GROWTH = 0.065
+
+
+DateBound = str | date | datetime | None
+
+
+def _windowed(
+    observations: list[dict[str, Any]],
+    *,
+    start_date: DateBound,
+    end_date: DateBound,
+) -> list[dict[str, Any]]:
+    if start_date is None and end_date is None:
+        return observations
+    return filter_observations_by_date_window(
+        observations,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+
+def fetch_gdp(
+    limit: int = 20,
+    *,
+    start_date: DateBound = None,
+    end_date: DateBound = None,
+) -> list[dict[str, Any]]:
+    """Fetch recent UK GDP at market prices observations (ONS series ABMI).
 
     Args:
-        limit: Number of most-recent quarterly observations to return.
+        limit: Maximum number of most-recent observations to return.
+        start_date: Optional inclusive window start.
+        end_date: Optional inclusive window end.
 
     Returns:
-        List of ``{"date": str, "value": str}`` dicts, oldest first.
-        Returns an empty list if the ONS API is unreachable.
+        List of ``{"date": str, "value": str}`` dicts, oldest first. Returns
+        an empty list if the ONS API is unreachable.
     """
     try:
-        obs = _fetch_timeseries(_GDP_SERIES, limit=limit)
+        obs = _fetch_timeseries("ABMI", limit=limit)
     except Exception:
         return []
+    obs = _windowed(obs, start_date=start_date, end_date=end_date)
     return obs[-limit:] if len(obs) > limit else obs
 
 
-def fetch_household_income(limit: int = 20) -> list[dict[str, Any]]:
-    """Fetch UK households' real disposable income observations.
-
-    Data is sourced from ONS series ``RPHQ`` (households and NPISH real
-    household disposable income, SA, chained-volume measure, GBP million).
-
-    Args:
-        limit: Number of most-recent quarterly observations to return.
-
-    Returns:
-        List of ``{"date": str, "value": str}`` dicts, oldest first.
-        Returns an empty list if the ONS API is unreachable.
-    """
+def fetch_household_income(
+    limit: int = 20,
+    *,
+    start_date: DateBound = None,
+    end_date: DateBound = None,
+) -> list[dict[str, Any]]:
+    """Fetch UK households' real disposable income observations (ONS RPHQ)."""
     try:
-        obs = _fetch_timeseries(_HOUSEHOLD_INCOME_SERIES, limit=limit)
+        obs = _fetch_timeseries("RPHQ", limit=limit)
     except Exception:
         return []
+    obs = _windowed(obs, start_date=start_date, end_date=end_date)
     return obs[-limit:] if len(obs) > limit else obs
 
 
-def fetch_savings_ratio(limit: int = 20) -> list[dict[str, Any]]:
-    """Fetch UK household saving ratio observations.
-
-    Data is sourced from ONS series ``NRJS`` (households and NPISH
-    saving ratio, SA, %).
-
-    Args:
-        limit: Number of most-recent quarterly observations to return.
-
-    Returns:
-        List of ``{"date": str, "value": str}`` dicts, oldest first.
-        Returns an empty list if the ONS API is unreachable.
-    """
+def fetch_savings_ratio(
+    limit: int = 20,
+    *,
+    start_date: DateBound = None,
+    end_date: DateBound = None,
+) -> list[dict[str, Any]]:
+    """Fetch UK household saving ratio observations (ONS NRJS)."""
     try:
-        obs = _fetch_timeseries(_SAVINGS_RATIO_SERIES, limit=limit)
+        obs = _fetch_timeseries("NRJS", limit=limit)
     except Exception:
         return []
+    obs = _windowed(obs, start_date=start_date, end_date=end_date)
     return obs[-limit:] if len(obs) > limit else obs
 
 
-def fetch_labour_market() -> dict[str, float | None]:
+def fetch_labour_market(
+    *,
+    start_date: DateBound = None,
+    end_date: DateBound = None,
+) -> dict[str, float | None]:
     """Fetch key UK labour market indicators.
 
-    Returns the latest values for unemployment rate and average weekly
-    earnings from the ONS Labour Force Survey and ASHE series.
-
-    Returns:
-        Dictionary with keys:
-
-        - ``"unemployment_rate"`` — LFS unemployment rate (%, SA).
-        - ``"average_weekly_earnings"`` — Average weekly earnings (GBP, SA).
-
-        Values are ``None`` if the ONS API is unreachable.
+    Returns the latest values for unemployment rate (MGSX) and average weekly
+    earnings (KAB9). When ``start_date`` / ``end_date`` are provided, the
+    latest value is taken from inside that window.
     """
+
+    def _latest(series_id: str) -> float | None:
+        try:
+            obs = _fetch_timeseries(series_id, limit=20)
+        except Exception:
+            return None
+        obs = _windowed(obs, start_date=start_date, end_date=end_date)
+        if not obs:
+            return None
+        try:
+            return float(obs[-1]["value"])
+        except (KeyError, ValueError, TypeError):
+            return None
+
+    if start_date is None and end_date is None:
+        return {
+            "unemployment_rate": _latest_float("MGSX"),
+            "average_weekly_earnings": _latest_float("KAB9"),
+        }
     return {
-        "unemployment_rate": _latest_float(_UNEMPLOYMENT_RATE_SERIES),
-        "average_weekly_earnings": _latest_float(_AVERAGE_EARNINGS_SERIES),
+        "unemployment_rate": _latest("MGSX"),
+        "average_weekly_earnings": _latest("KAB9"),
     }
 
 
 def fetch_tenure_distribution() -> dict[str, float]:
     """Fetch the UK housing tenure distribution.
 
-    Returns shares for owner-occupiers, private renters, and social renters.
-    Falls back to English Housing Survey 2023-24 values when live data is
-    unavailable.
-
-    Returns:
-        Dict mapping tenure type to share (0-1).
+    No live API equivalent exists; returns the EHS 2023-24 fallback values.
     """
     logger.info("Using EHS 2023-24 tenure distribution (fallback)")
     return dict(_FALLBACK_TENURE)
 
 
-def fetch_affordability_ratio() -> float:
+def fetch_affordability_ratio(
+    *,
+    start_date: DateBound = None,
+    end_date: DateBound = None,
+) -> float:
     """Fetch the median house price to workplace earnings affordability ratio.
 
-    Uses ONS series ``HP7A`` (median workplace-based affordability ratio for
-    England and Wales).
-
-    Returns:
-        Median price-to-income ratio, or the fallback value of 8.3 when the
-        API is unavailable.
+    Uses ONS series ``HP7A`` via the dataset API. Falls back to the
+    workflow-level constant when the API is unavailable.
     """
-    return _fetch_affordability_ratio()
+    try:
+        obs = _fetch_timeseries("HP7A", limit=1)
+        obs = _windowed(obs, start_date=start_date, end_date=end_date)
+        if obs:
+            value = float(obs[-1]["value"])
+            if value > 0:
+                logger.info("Fetched affordability ratio: %.1f", value)
+                return value
+    except Exception:
+        logger.warning("ONS affordability series unavailable, using fallback")
+    return _FALLBACK_AFFORDABILITY
 
 
-def fetch_rental_growth() -> float:
-    """Fetch the annual private rental price growth rate.
+def fetch_rental_growth(
+    *,
+    start_date: DateBound = None,
+    end_date: DateBound = None,
+) -> float:
+    """Fetch the annual private rental price growth rate (ONS series D7RA).
 
-    Uses ONS series ``D7RA`` (Index of Private Housing Rental Prices,
-    monthly).  Computes year-on-year growth from the most recent 13 months.
-
-    Returns:
-        Annual rental price growth as a decimal (e.g. 0.065 for 6.5%),
-        or the fallback value when data is unavailable.
+    Computes year-on-year growth from the most recent 13 monthly
+    observations. Falls back to the workflow-level constant when the API is
+    unavailable or fewer than 13 months are returned.
     """
-    return _fetch_rental_growth()
+    try:
+        obs = _fetch_timeseries("D7RA", limit=13)
+        obs = _windowed(obs, start_date=start_date, end_date=end_date)
+        if len(obs) >= 13:
+            latest = float(obs[-1]["value"])
+            year_ago = float(obs[0]["value"])
+            if year_ago > 0 and latest > 0:
+                growth = (latest / year_ago) - 1.0
+                logger.info("Fetched rental growth: %.1f%%", growth * 100)
+                return growth
+    except Exception:
+        logger.warning("ONS rental index unavailable, using fallback")
+    return _FALLBACK_RENTAL_GROWTH

--- a/packages/uk-data/tests/adapters/test_ons.py
+++ b/packages/uk-data/tests/adapters/test_ons.py
@@ -2,31 +2,37 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
-from uk_data.adapters.ons import ONSAdapter
-from uk_data.adapters.ons_models import (
-    Observation,
-    ObservationDimensions,
-    ONSObservation,
-    TimeDimension,
-)
+from uk_data.adapters.ons import _SERIES_DATASET, ONSAdapter
+from uk_data.storage.canonical import CanonicalStore
+from uk_data.storage.raw import RawStore
 
 ONS_SERIES_IDS = ["ABMI", "RPHQ", "NRJS", "MGSX", "KAB9", "HP7A", "D7RA"]
 
 
-def _make_ons_observation(rows: list[dict[str, str]]) -> ONSObservation:
-    """Build an ONSObservation with one Observation per row dict."""
-    return ONSObservation(
-        observations=[
-            Observation(
-                dimensions=ObservationDimensions(time=TimeDimension(id=row["date"])),
-                observation=float(row["value"]),
-            )
+def _raw_payload(rows: list[dict[str, str]]) -> dict[str, Any]:
+    """Build a raw dataset-API observation payload (plain dicts, not pydantic)."""
+    return {
+        "dimensions": {},
+        "observations": [
+            {
+                "dimensions": {"time": {"id": row["date"]}},
+                "observation": row["value"],
+            }
             for row in rows
-        ]
+        ],
+        "limit": len(rows),
+    }
+
+
+def _make_adapter(tmp_path) -> ONSAdapter:
+    return ONSAdapter(
+        store=RawStore(tmp_path),
+        canonical_store=CanonicalStore(tmp_path),
     )
 
 
@@ -51,132 +57,220 @@ class TestONSAdapterAvailableSeries:
         assert len(series) == len(set(series))
 
 
-class TestONSAdapterFetchSeriesOffline:
-    """Mock the dataset observation layer so ONS tests never hit the network."""
+class TestONSAdapterExtract:
+    """Stage 1: extract fetches raw JSON and writes it to the RawStore."""
 
-    def _mock_quarterly_observations(self) -> list[dict[str, str]]:
-        return [
+    def test_extract_writes_raw_payload_and_returns_key(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        rows = [{"date": "2024Q1", "value": "100.0"}]
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ) as mocked:
+            key = adapter.extract(
+                "ukea", "time-series", "latest", timeseries="ABMI", time="*"
+            )
+
+        assert mocked.call_count == 1
+        # The raw payload was persisted under a deterministic key.
+        files = list((tmp_path / "raw" / "ons" / key).glob("*.json"))
+        assert len(files) == 1
+        assert "timeseries=ABMI" in key
+        assert "time=*" in key
+
+    def test_extract_does_not_validate_with_pydantic(self, tmp_path) -> None:
+        """Extract must accept raw payloads that would fail pydantic validation."""
+        adapter = _make_adapter(tmp_path)
+        # Missing 'observations' key entirely; pydantic would still parse, but
+        # we verify get_json is called and payload reaches the store untouched.
+        weird_payload = {"foo": "bar", "garbage": [1, 2, 3]}
+        with patch("uk_data.adapters.ons.get_json", return_value=weird_payload):
+            key = adapter.extract("dataset_x", "time-series", "1")
+
+        files = list((tmp_path / "raw" / "ons" / key).glob("*.json"))
+        assert len(files) == 1
+
+    def test_extract_series_uses_registry(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        rows = [{"date": "2024Q1", "value": "100.0"}]
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ) as mocked:
+            key = adapter.extract_series("ABMI")
+
+        assert mocked.call_count == 1
+        cfg = _SERIES_DATASET["ABMI"]
+        assert cfg["dataset_id"] in mocked.call_args.args[0]
+        assert "timeseries=ABMI" in key
+
+    def test_extract_series_rejects_unknown_series(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        with pytest.raises(ValueError, match="Unsupported ONS series"):
+            adapter.extract_series("NOT_A_SERIES")
+
+
+class TestONSAdapterTransform:
+    """Stage 2: transform validates raw and persists to canonical."""
+
+    def test_transform_round_trips_raw_to_canonical(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        rows = [
             {"date": "2024Q1", "value": "100.0"},
             {"date": "2024Q2", "value": "101.5"},
         ]
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ):
+            key = adapter.extract_series("ABMI")
 
-    def _mock_monthly_observations(self) -> list[dict[str, str]]:
-        return [
-            {"date": "2024-01-01", "value": "4.2"},
-            {"date": "2024-02-01", "value": "4.1"},
+        ts = adapter.transform(key)
+        assert ts.source == "ons"
+        assert ts.source_series_id == "ABMI"
+        assert ts.values.tolist() == pytest.approx([100.0, 101.5])
+
+        canonical_path = tmp_path / "canonical" / "timeseries" / "ons.parquet"
+        assert canonical_path.exists()
+
+    def test_transform_missing_key_raises(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            adapter.transform("nonexistent/key")
+
+    def test_transform_invalid_payload_raises(self, tmp_path) -> None:
+        """Pydantic validation surfaces from transform, not extract."""
+        adapter = _make_adapter(tmp_path)
+        # Save a payload whose 'observation' values cannot be coerced to float.
+        bad_payload = {
+            "observations": [
+                {
+                    "dimensions": {"time": {"id": "2024Q1"}},
+                    "observation": "not-a-number",
+                }
+            ]
+        }
+        with patch("uk_data.adapters.ons.get_json", return_value=bad_payload):
+            key = adapter.extract_series("ABMI")
+
+        with pytest.raises(Exception):  # noqa: B017 — pydantic ValidationError
+            adapter.transform(key)
+
+
+class TestONSAdapterFetchSeriesFromCanonical:
+    """Stage 3: fetch_series reads canonical store only — never the network."""
+
+    def test_round_trip_returns_canonical_series(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        rows = [
+            {"date": "2024Q1", "value": "100.0"},
+            {"date": "2024Q2", "value": "101.5"},
         ]
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ):
+            key = adapter.extract_series("ABMI")
+            adapter.transform(key)
 
-    def _patch_get_observation(self, observations: list[dict[str, str]]) -> patch:  # type: ignore[type-arg]
-        return patch(
-            "uk_data.adapters.ons.ONSAdapter.get_observation",
-            return_value=_make_ons_observation(observations),
-        )
-
-    def test_manifest_backed_series_returns_timeseries_for_abmi(self) -> None:
-        with self._patch_get_observation(self._mock_quarterly_observations()):
-            adapter = ONSAdapter()
+        # fetch_series must not hit the network at all.
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            side_effect=AssertionError("fetch_series should not call the API"),
+        ):
             ts = adapter.fetch_series("ABMI")
-            assert ts.source == "ons"
-            assert ts.source_series_id == "ABMI"
-            assert ts.latest_value == pytest.approx(101.5)
 
-    def test_manifest_backed_series_returns_timeseries_for_mgsx(self) -> None:
-        with self._patch_get_observation(self._mock_monthly_observations()):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series("MGSX")
-            assert ts.source == "ons"
-            assert ts.latest_value == pytest.approx(4.1)
+        assert ts.source == "ons"
+        assert ts.source_series_id == "ABMI"
+        assert ts.values.tolist() == pytest.approx([100.0, 101.5])
+        assert ts.latest_value == pytest.approx(101.5)
 
-    def test_manifest_backed_series_sets_source_and_source_series_id(self) -> None:
-        with self._patch_get_observation(self._mock_quarterly_observations()):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series("RPHQ")
-            assert ts.source == "ons"
-            assert ts.source_series_id == "RPHQ"
+    def test_fetch_series_raises_when_canonical_missing(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            adapter.fetch_series("ABMI")
 
-    def test_manifest_backed_series_converts_dates_and_numeric_values(self) -> None:
-        with self._patch_get_observation(self._mock_quarterly_observations()):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series("NRJS")
-            assert ts.values.tolist() == pytest.approx([100.0, 101.5])
-            assert str(ts.timestamps[0]) == "2024-01-01T00:00:00.000000000"
-
-    def test_affordability_series_still_uses_fallback_point_series(self) -> None:
-        with patch(
-            "uk_data.adapters.ons._fetch_affordability_ratio",
-            return_value=8.5,
-        ):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series("HP7A")
-            assert ts.source == "ons"
-            assert ts.latest_value == pytest.approx(8.5)
-
-    def test_rental_growth_series_still_uses_fallback_point_series(self) -> None:
-        with patch(
-            "uk_data.adapters.ons._fetch_rental_growth",
-            return_value=0.03,
-        ):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series("D7RA")
-            assert ts.source == "ons"
-            assert ts.latest_value == pytest.approx(0.03)
-
-    def test_unsupported_series_raises(self) -> None:
+    def test_fetch_series_raises_without_canonical_store(self) -> None:
         adapter = ONSAdapter()
-        with pytest.raises(ValueError, match="Unsupported ONS series"):
-            adapter.fetch_series("NOTREAL_SERIES_ID")
+        with pytest.raises(FileNotFoundError):
+            adapter.fetch_series("ABMI")
 
-    def test_sdmx_series_applies_inclusive_date_window(self) -> None:
-        observations = [
+    def test_fetch_series_unsupported_id_raises(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        with pytest.raises(ValueError, match="Unsupported ONS series"):
+            adapter.fetch_series("NOT_REAL")
+
+    def test_fetch_series_applies_inclusive_date_window(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        rows = [
             {"date": "2023-12-31", "value": "1.0"},
             {"date": "2024-01-01", "value": "2.0"},
             {"date": "2024-03-31", "value": "3.0"},
             {"date": "2024-04-01", "value": "4.0"},
         ]
-        with self._patch_get_observation(observations):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series(
-                "ABMI",
-                start_date="2024-01-01",
-                end_date="2024-03-31",
-            )
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ):
+            key = adapter.extract_series("ABMI")
+            adapter.transform(key)
 
+        ts = adapter.fetch_series(
+            "ABMI",
+            start_date="2024-01-01",
+            end_date="2024-03-31",
+        )
         assert ts.values.tolist() == pytest.approx([2.0, 3.0])
 
-    def test_sdmx_series_filters_before_limit(self) -> None:
-        observations = [
+    def test_fetch_series_filters_before_limit(self, tmp_path) -> None:
+        adapter = _make_adapter(tmp_path)
+        rows = [
             {"date": "2024-01-01", "value": "1.0"},
             {"date": "2024-02-01", "value": "2.0"},
             {"date": "2024-03-01", "value": "3.0"},
             {"date": "2024-04-01", "value": "4.0"},
         ]
-        with self._patch_get_observation(observations):
-            adapter = ONSAdapter()
-            ts = adapter.fetch_series(
-                "ABMI",
-                start_date="2024-01-01",
-                end_date="2024-03-01",
-                limit=2,
-            )
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ):
+            key = adapter.extract_series("ABMI")
+            adapter.transform(key)
 
+        ts = adapter.fetch_series(
+            "ABMI",
+            start_date="2024-01-01",
+            end_date="2024-03-01",
+            limit=2,
+        )
         assert ts.values.tolist() == pytest.approx([2.0, 3.0])
 
-    def test_sdmx_series_passes_correct_dimensions_to_get_observation(self) -> None:
+    def test_fetch_series_for_affordability_via_dataset_api(self, tmp_path) -> None:
+        """HP7A flows through the dataset API like every other series."""
+        adapter = _make_adapter(tmp_path)
+        rows = [{"date": "2023", "value": "8.5"}]
         with patch(
-            "uk_data.adapters.ons.ONSAdapter.get_observation",
-            return_value=_make_ons_observation(
-                [{"date": "2024-01-01", "value": "2.0"}]
-            ),
-        ) as mocked_fetch:
-            adapter = ONSAdapter()
-            adapter.fetch_series(
-                "ABMI",
-                start_date="2024-01-01",
-                end_date="2024-03-31",
-                limit=5,
-            )
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ):
+            key = adapter.extract_series("HP7A")
+            adapter.transform(key)
 
-        mocked_fetch.assert_called_once()
-        _, kwargs = mocked_fetch.call_args
-        assert kwargs["timeseries"] == "ABMI"
-        assert kwargs["time"] == "*"
+        ts = adapter.fetch_series("HP7A")
+        assert ts.source == "ons"
+        assert ts.source_series_id == "HP7A"
+        assert ts.latest_value == pytest.approx(8.5)
+
+    def test_fetch_series_for_rental_growth_via_dataset_api(self, tmp_path) -> None:
+        """D7RA flows through the dataset API like every other series."""
+        adapter = _make_adapter(tmp_path)
+        rows = [{"date": "2024-01-01", "value": "0.05"}]
+        with patch(
+            "uk_data.adapters.ons.get_json",
+            return_value=_raw_payload(rows),
+        ):
+            key = adapter.extract_series("D7RA")
+            adapter.transform(key)
+
+        ts = adapter.fetch_series("D7RA")
+        assert ts.latest_value == pytest.approx(0.05)

--- a/packages/uk-data/tests/adapters/test_ons_dataset_api.py
+++ b/packages/uk-data/tests/adapters/test_ons_dataset_api.py
@@ -14,7 +14,7 @@ from uk_data.adapters.ons_models import (
 
 
 class TestONSDatasetAPI:
-    def test_list_datasets_returns_typed_models_and_caches_by_args(self) -> None:
+    def test_get_datasets_returns_typed_models_and_caches_by_args(self) -> None:
         payload = {
             "items": [
                 {
@@ -28,10 +28,8 @@ class TestONSDatasetAPI:
         with patch("uk_data.adapters.ons.get_json", return_value=payload) as mocked_get:
             adapter = ONSAdapter()
 
-            first = adapter.list_datasets(limit=20, offset=0, dataset_type="timeseries")
-            second = adapter.list_datasets(
-                limit=20, offset=0, dataset_type="timeseries"
-            )
+            first = adapter.get_datasets(limit=20, offset=0, dataset_type="timeseries")
+            second = adapter.get_datasets(limit=20, offset=0, dataset_type="timeseries")
 
         assert first == second
         assert isinstance(first[0], ONSDatasetInfo)

--- a/packages/uk-data/tests/adapters/test_ons_integration.py
+++ b/packages/uk-data/tests/adapters/test_ons_integration.py
@@ -3,7 +3,7 @@
 Run with::
 
     uv run pytest -m integration \
-        packages/uk-data-client/tests/adapters/test_ons_integration.py
+        packages/uk-data/tests/adapters/test_ons_integration.py
 """
 
 from __future__ import annotations
@@ -19,11 +19,13 @@ from uk_data.adapters.ons_models import (
     ONSObservation,
 )
 from uk_data.models import TimeSeries
+from uk_data.storage.canonical import CanonicalStore
+from uk_data.storage.raw import RawStore
 from uk_data.utils.http import clear_cache
 
 pytestmark = pytest.mark.integration
 
-_ONS_URL = "https://api.ons.gov.uk/v1"
+_ONS_URL = "https://api.beta.ons.gov.uk/v1"
 
 
 def _skip_if_cannot_reach(url: str) -> None:
@@ -33,83 +35,103 @@ def _skip_if_cannot_reach(url: str) -> None:
         pytest.skip(f"Network unavailable or {url} unreachable")
 
 
+def _make_live_adapter(tmp_path) -> ONSAdapter:
+    return ONSAdapter(
+        store=RawStore(tmp_path),
+        canonical_store=CanonicalStore(tmp_path),
+    )
+
+
+def _refresh(adapter: ONSAdapter, series_id: str) -> TimeSeries:
+    key = adapter.extract_series(series_id)
+    return adapter.transform(key)
+
+
 class TestONSAdapterIntegration:
     """Verify every ONS series ID in available_series() can be fetched live."""
 
-    def test_gdp_series_live(self) -> None:
+    def test_gdp_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "ABMI")
         ts = adapter.fetch_series("ABMI")
         assert isinstance(ts, TimeSeries)
         assert ts.source == "ons"
         assert ts.latest_value is not None
         assert ts.latest_value > 0, "GDP should be positive"
 
-    def test_household_income_series_live(self) -> None:
+    def test_household_income_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "RPHQ")
         ts = adapter.fetch_series("RPHQ")
         assert ts.source == "ons"
         assert ts.latest_value is not None
 
-    def test_savings_ratio_series_live(self) -> None:
+    def test_savings_ratio_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "NRJS")
         ts = adapter.fetch_series("NRJS")
         assert ts.source == "ons"
         assert ts.latest_value is not None
 
-    def test_unemployment_series_live(self) -> None:
+    def test_unemployment_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "MGSX")
         ts = adapter.fetch_series("MGSX")
         assert ts.source == "ons"
         assert ts.latest_value is not None
         assert 0 <= ts.latest_value <= 30, "UK unemployment rate should be 0-30%"
 
-    def test_average_earnings_series_live(self) -> None:
+    def test_average_earnings_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "KAB9")
         ts = adapter.fetch_series("KAB9")
         assert ts.source == "ons"
         assert ts.latest_value is not None
         assert ts.latest_value > 0, "Average weekly earnings should be positive"
 
-    def test_affordability_series_live(self) -> None:
+    def test_affordability_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "HP7A")
         ts = adapter.fetch_series("HP7A")
         assert ts.source == "ons"
         assert ts.latest_value is not None
 
-    def test_rental_index_series_live(self) -> None:
+    def test_rental_index_series_live(self, tmp_path) -> None:
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
+        _refresh(adapter, "D7RA")
         ts = adapter.fetch_series("D7RA")
         assert ts.source == "ons"
         assert ts.latest_value is not None
 
-    def test_all_advertised_series_fetchable_live(self) -> None:
-        """Parametric: every series in available_series() must succeed live."""
+    def test_all_advertised_series_fetchable_live(self, tmp_path) -> None:
+        """Parametric: every series in available_series() must round-trip live."""
         _skip_if_cannot_reach(_ONS_URL)
 
         clear_cache()
-        adapter = ONSAdapter()
+        adapter = _make_live_adapter(tmp_path)
         for series_id in adapter.available_series():
+            _refresh(adapter, series_id)
             ts = adapter.fetch_series(series_id)
             assert ts is not None, f"ONS series {series_id!r} returned None"
             assert ts.source == "ons"
@@ -117,9 +139,9 @@ class TestONSAdapterIntegration:
                 f"ONS series {series_id!r} returned null latest_value"
             )
 
-    def test_list_datasets_live(self) -> None:
+    def test_get_datasets_live(self) -> None:
         adapter = ONSAdapter()
-        result = adapter.list_datasets()
+        result = adapter.get_datasets()
         assert isinstance(result, list), "Expected list of datasets"
         assert isinstance(result[0], ONSDatasetInfo), "Expected dataset details"
 
@@ -134,7 +156,6 @@ class TestONSAdapterIntegration:
         assert isinstance(version, ONSDatasetVersionInfo), "Expected version details"
 
     def test_get_observations_live(self) -> None:
-
         adapter = ONSAdapter()
         result = adapter.get_observation(
             "cpih01",

--- a/tests/test_data_sources_integration.py
+++ b/tests/test_data_sources_integration.py
@@ -30,13 +30,7 @@ from uk_data.adapters.hmrc import (
     get_vat_rate,
 )
 from uk_data.adapters.land_registry import fetch_regional_prices, fetch_uk_average_price
-from uk_data.adapters.ons import (
-    _DEFAULT_URI_TEMPLATE,
-    _FALLBACK_AFFORDABILITY,
-    _FALLBACK_RENTAL_GROWTH,
-    _SERIES_URI,
-    _fetch_timeseries,
-)
+from uk_data.adapters.ons import _fetch_timeseries
 from uk_data.utils import http as _http
 from uk_data.utils.http import clear_cache
 from uk_data.workflows.boe import (
@@ -46,6 +40,8 @@ from uk_data.workflows.boe import (
     get_aggregate_capital_ratio,
 )
 from uk_data.workflows.ons import (
+    _FALLBACK_AFFORDABILITY,
+    _FALLBACK_RENTAL_GROWTH,
     fetch_affordability_ratio,
     fetch_gdp,
     fetch_household_income,
@@ -477,132 +473,59 @@ class TestHmrcFunctionsIntegration:
 
 
 # ---------------------------------------------------------------------------
-# ONS _fetch_timeseries URL-construction unit tests
+# ONS _fetch_timeseries URL-construction unit tests (dataset API)
 # ---------------------------------------------------------------------------
 
 
 class TestOnsFetchTimeseriesUrlConstruction:
-    """Verify _fetch_timeseries builds the correct ?uri= URL for each series."""
+    """Verify _fetch_timeseries builds dataset-API URLs for each series."""
 
     def _captured_urls(self, series_ids: list[str]) -> list[str]:
-        """Return the URLs that _fetch_timeseries would request for each series."""
-
         _http.clear_cache()
         captured: list[str] = []
 
-        def _fake_retry(fn: object, url: str) -> dict:  # type: ignore[type-arg]
+        def _fake_get_json(url: str) -> dict:  # type: ignore[type-arg]
             captured.append(url)
-            return {"quarters": [{"date": "2024 Q4", "value": "100"}]}
+            return {
+                "observations": [
+                    {
+                        "dimensions": {"time": {"id": "2024Q4"}},
+                        "observation": "100",
+                    }
+                ]
+            }
 
-        with patch("uk_data.adapters.ons.retry", side_effect=_fake_retry):
+        with patch("uk_data.adapters.ons.get_json", side_effect=_fake_get_json):
             for sid in series_ids:
                 _fetch_timeseries(sid, limit=1)
 
         return captured
 
-    def test_abmi_uses_gdp_topic(self) -> None:
+    def test_url_uses_dataset_observations_endpoint(self) -> None:
+        urls = self._captured_urls(["ABMI", "MGSX", "KAB9"])
+        for url in urls:
+            assert "/datasets/" in url, f"Expected /datasets/ path in {url!r}"
+            assert "/observations" in url, f"Expected /observations endpoint in {url!r}"
+            assert "/v1/data?uri=" not in url, (
+                f"Legacy Zebedee URL pattern still used: {url!r}"
+            )
+
+    def test_abmi_routes_to_ukea_dataset(self) -> None:
         urls = self._captured_urls(["ABMI"])
         assert len(urls) == 1
-        assert "uri=" in urls[0]
-        assert "abmi" in urls[0]
-        assert "ukea" in urls[0]
-        # Must NOT use the old path pattern
-        assert "/timeseries/abmi/dataset/" not in urls[0]
+        assert "/datasets/ukea/" in urls[0]
+        assert "timeseries=ABMI" in urls[0]
 
-    def test_rphq_uses_gdp_topic(self) -> None:
-        urls = self._captured_urls(["RPHQ"])
-        assert "rphq" in urls[0]
-        assert "ukea" in urls[0]
-
-    def test_nrjs_uses_gdp_topic(self) -> None:
-        urls = self._captured_urls(["NRJS"])
-        assert "nrjs" in urls[0]
-        assert "ukea" in urls[0]
-
-    def test_mgsx_uses_lms_topic(self) -> None:
-        urls = self._captured_urls(["MGSX"])
-        assert "mgsx" in urls[0]
-        assert "lms" in urls[0]
-        assert "unemployment" in urls[0]
-
-    def test_kab9_uses_lms_topic(self) -> None:
-        urls = self._captured_urls(["KAB9"])
-        assert "kab9" in urls[0]
-        assert "lms" in urls[0]
-        assert "earnings" in urls[0]
-
-    def test_url_uses_data_endpoint_with_uri_param(self) -> None:
-        """All URLs must use /v1/data?uri= not /v1/timeseries/...."""
-        urls = self._captured_urls(["ABMI", "MGSX", "KAB9", "L2KL"])
+    def test_lms_series_route_to_lms_dataset(self) -> None:
+        urls = self._captured_urls(["MGSX", "KAB9"])
         for url in urls:
-            assert "/v1/data" in url, f"Expected /v1/data endpoint in {url!r}"
-            assert "uri=" in url, f"Expected uri= param in {url!r}"
-            assert "/timeseries/" not in url.split("uri=")[0], (
-                f"Old path-segment style used before uri= in {url!r}"
-            )
+            assert "/datasets/lms/" in url
 
-    def test_gva_series_use_gdp_topic(self) -> None:
-        urls = self._captured_urls(["L2KL", "L2N8", "L2NC", "L2NE"])
-        for url in urls:
-            assert "grossdomesticproductgdp" in url
-            assert "ukea" in url
-
-
-class TestOnsSeriesUriMapping:
-    """Verify _SERIES_URI and _DEFAULT_URI_TEMPLATE are internally consistent."""
-
-    def test_series_uri_keys_are_uppercase(self) -> None:
-
-        for key in _SERIES_URI:
-            assert key == key.upper(), f"Key {key!r} should be uppercase"
-
-    def test_series_uri_values_start_with_slash(self) -> None:
-
-        for sid, uri in _SERIES_URI.items():
-            assert uri.startswith("/"), f"URI for {sid!r} should start with /"
-
-    def test_series_uri_values_contain_timeseries(self) -> None:
-
-        for sid, uri in _SERIES_URI.items():
-            assert "timeseries" in uri.lower(), (
-                f"URI for {sid!r} does not contain 'timeseries': {uri!r}"
-            )
-
-    def test_default_template_substitution(self) -> None:
-
-        result = _DEFAULT_URI_TEMPLATE.format(sid="abcd")
-        assert "abcd" in result
-        assert result.startswith("/")
-
-    def test_only_confirmed_gva_series_present(self) -> None:
-        """Only L2KL, L2N8, L2NC, L2NE should be in _SERIES_URI (confirmed working)."""
-
-        confirmed_gva = {"L2KL", "L2N8", "L2NC", "L2NE"}
-        removed_gva = {
-            "L2KP",
-            "L2ND",
-            "L2NF",
-            "L2NG",
-            "L2NI",
-            "L2NJ",
-            "L2NK",
-            "L2NL",
-            "L2NM",
-        }
-        for sid in confirmed_gva:
-            assert sid in _SERIES_URI, (
-                f"Confirmed GVA series {sid!r} missing from _SERIES_URI"
-            )
-        for sid in removed_gva:
-            assert sid not in _SERIES_URI, (
-                f"Broken GVA series {sid!r} should not be in _SERIES_URI"
-            )
-
-    def test_hp7a_and_d7ra_not_in_series_uri(self) -> None:
-        """HP7A and D7RA are not accessible via Zebedee; should not be mapped."""
-
-        assert "HP7A" not in _SERIES_URI, "HP7A not available on Zebedee API"
-        assert "D7RA" not in _SERIES_URI, "D7RA not available on Zebedee API"
+    def test_unregistered_series_falls_back_to_ukea(self) -> None:
+        """GVA series like L2KL aren't in _SERIES_DATASET; fall back to ukea."""
+        urls = self._captured_urls(["L2KL"])
+        assert "/datasets/ukea/" in urls[0]
+        assert "timeseries=L2KL" in urls[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Split ONS observation handling into three explicit stages so raw
payloads are persisted before pydantic touches them:

- `extract(dataset_id, edition, version, **dimensions)` writes the raw
  JSON to the RawStore unvalidated and returns a deterministic key.
  `extract_series(series_id)` wraps this for the seven advertised
  series via the new `_SERIES_DATASET` registry.
- `transform(key)` loads raw from the RawStore, validates with
  `ONSObservation`, builds a canonical `TimeSeries`, and upserts it to
  the CanonicalStore at `timeseries/ons.parquet`.
- `fetch_series` reads only from the CanonicalStore and raises
  `FileNotFoundError` if no extract+transform has run.

`list_datasets` is renamed to `get_datasets` to match the public
discovery surface; it and the other typed discovery helpers
(`get_dataset`, `get_version`, `get_observation`) keep returning pydantic
models. Workflow-level fallback constants (`_FALLBACK_AFFORDABILITY`,
`_FALLBACK_RENTAL_GROWTH`, `_FALLBACK_TENURE`) move to `workflows/ons.py`
so the adapter is fallback-free; workflow helpers gain optional
`start_date`/`end_date` parameters consistent with the rest of the API.

Adds `timeseries_to_frame` / `frame_to_timeseries` helpers and extends
`BaseAdapter` to accept a `CanonicalStore`.

## Testing and Verification

### Offline unit tests (no network required)

```bash
# Run all ONS adapter unit tests
uv run pytest packages/uk-data/tests/adapters/test_ons.py \
               packages/uk-data/tests/adapters/test_ons_dataset_api.py -v

# Run the full offline test suite
uv run pytest -m "not integration and not slow"
```

### Smoke-test the three-stage pipeline end-to-end

```python
from pathlib import Path
from uk_data.adapters.ons import ONSAdapter
from uk_data.storage.canonical import CanonicalStore
from uk_data.storage.raw import RawStore

root = Path("/tmp/uk-data-smoke")
adapter = ONSAdapter(store=RawStore(root), canonical_store=CanonicalStore(root))

# Stage 1 — fetch raw JSON, write to RawStore (no pydantic)
key = adapter.extract_series("ABMI")
print(f"Raw key: {key}")
print(f"Raw file: {list((root / 'raw' / 'ons' / key).glob('*.json'))}")

# Stage 2 — validate with pydantic, write to CanonicalStore
ts = adapter.transform(key)
print(f"Transformed: {ts.latest_value}")
print(f"Canonical parquet: {root / 'canonical' / 'timeseries' / 'ons.parquet'}")

# Stage 3 — read from canonical only (no further network requests)
ts2 = adapter.fetch_series("ABMI")
print(f"Fetched from canonical: {ts2.latest_value}")
assert ts.latest_value == ts2.latest_value
```

Running this script twice should hit the network on `extract` (writes a new timestamped raw file), but `fetch_series` is entirely offline.

### Verify fetch_series raises when canonical is empty

```python
from pathlib import Path
from uk_data.adapters.ons import ONSAdapter
from uk_data.storage.canonical import CanonicalStore
from uk_data.storage.raw import RawStore

adapter = ONSAdapter(
    store=RawStore(Path("/tmp/empty-store")),
    canonical_store=CanonicalStore(Path("/tmp/empty-store")),
)
try:
    adapter.fetch_series("ABMI")
    assert False, "Should have raised"
except FileNotFoundError as e:
    print(f"Correctly raised: {e}")
```

### Verify workflow functions still work (with fallback)

```bash
uv run python -c "
from uk_data.workflows.ons import (
    fetch_gdp, fetch_affordability_ratio, fetch_rental_growth, fetch_labour_market
)
print('GDP obs:', len(fetch_gdp(limit=5)))
print('Affordability ratio:', fetch_affordability_ratio())
print('Rental growth:', fetch_rental_growth())
print('Labour market:', fetch_labour_market())
"
```

### Verify HP7A and D7RA dataset IDs (integration)

> **⚠️ The dataset IDs for HP7A and D7RA in `_SERIES_DATASET` are best-guess values that need verification against the live ONS API.**

```bash
uv run pytest packages/uk-data/tests/adapters/test_ons_integration.py \
               -m integration \
               -k "affordability or rental" -v
```

If these tests fail with HTTP 404, find the correct dataset IDs via:

```python
from uk_data.adapters.ons import ONSAdapter
adapter = ONSAdapter()
datasets = adapter.get_datasets(limit=200)
housing = [d for d in datasets if any(k in (d.title or "").lower()
           for k in ["rental", "afford", "housing"])]
for d in housing:
    print(d.id, d.title)
```

Then update `_SERIES_DATASET` in `packages/uk-data/src/uk_data/adapters/ons.py`.

### Integration tests (requires ONS API access)

```bash
uv run pytest packages/uk-data/tests/adapters/test_ons_integration.py -m integration -v
uv run pytest tests/test_data_sources_integration.py -m integration -v
```

### Lint and type checks

```bash
make verify
# Expected: ruff clean, format clean, 56 ty warnings (all pre-existing)
```

https://claude.ai/code/session_018GyYSjNCbRghLgRXq9eHvW